### PR TITLE
Do not copy prompts for pycon/console blocks

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -34,7 +34,7 @@ With PyPalmSens, you can:
 
 To install:
 
-```python
+```bash
 pip install pypalmsens
 ```
 

--- a/python/docs/zensical/circuit_fitting.md
+++ b/python/docs/zensical/circuit_fitting.md
@@ -6,7 +6,7 @@ specifying the frequency range to fit, limiting the number of iterations, delta 
 
 Example usage for fitting an equivalent circuit:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> measurements = ps.load_session_file('eis_data.pssession')
@@ -27,7 +27,7 @@ FitResult(cdc='R(RC)', parameters=[564.65, 10077.11, 3.327e-08], chisq=0.00040, 
 errors, and other fitting data.
 You can pass `result.parameters` back to [pypalmsens.fitting.CircuitModel.fit][]) to redo the fit:
 
-```python
+```pycon
 >>> result = model.fit(eis_data, parameters=result.parameters)
 ```
 
@@ -38,7 +38,7 @@ bounds, you can set them using the [pypalmsens.fitting.Parameters][] class.
 `model.default_parameters` grabs the default parameters for the CDC.
 These can be modified, for example:
 
-```python
+```pycon
 >>> parameters = model.default_parameters()
 
 >>> parameters[0].value = 123  # set starting value to 123
@@ -53,7 +53,7 @@ These can be modified, for example:
 
 If you have already fitted your data in PSTrace, you can redo the fit or use the values as starting parameters:
 
-```python
+```pycon
 >>> model = ps.fitting.CircuitModel(cdc=eisdata.cdc)
 >>> result = model.fit(eisdata, parameters=eisdata.cdc_values)
 ```
@@ -63,7 +63,7 @@ If you have already fitted your data in PSTrace, you can redo the fit or use the
 If you have [matplotlib](https://matplotlib.org) installed, you can
 generate the plots from the result:
 
-```python
+```pycon
 >>> result.plot_nyquist(eis_data)
 >>> result.plot_bode(eis_data)
 ```

--- a/python/docs/zensical/data.md
+++ b/python/docs/zensical/data.md
@@ -10,7 +10,7 @@ The top level object is a [Measurement][pypalmsens.data.Measurement].
 The Measurement class contains information about the method, data, and experiment metadata.
 
 
-```python
+```pycon
 >>> import pypalmsens as ps
 >>> measurements = ps.load_session_file('Demo CV DPV EIS IS-C electrode.pssession')
 >>> measurements
@@ -22,20 +22,20 @@ The Measurement class contains information about the method, data, and experimen
 Note that a session file (`.pssession`) can contain multiple measurements.
 Therefore, [pypalmsens.load_session_file][] always returns a list of measurements. You can select the first measurement (DPV) using index `[0]`:
 
-```python
+```pycon
 >>> measurement = measurements[0]
 ```
 
 From there, you can query device information and other metadata:
 
-```python
+```pycon
 >>> measurement.device
 DeviceInfo(type='PalmSens4', firmware='', serial='PS4A16A000003', id=9)
 ```
 
 And measurement details like title and timestamp:
 
-```python
+```pycon
 >>> measurement.title
 'Differential Pulse Voltammetry'
 >>> measurement.timestamp
@@ -58,7 +58,7 @@ For more information, see the [pypalmsens.data.Measurement][].
 A measurement can contain multiple curves, therefore `measurement.curves` returns a list.
 The example below has only one curve with 219 data points:
 
-```python
+```pycon
 >>> curves = measurement.curves
 >>> curves
 [Curve(title=Curve, n_points=219)]
@@ -67,7 +67,7 @@ The example below has only one curve with 219 data points:
 
 You can query some [Curve][pypalmsens.data.Curve] metadata like this:
 
-```python
+```pycon
 >>> curve.title
 Curve
 >>> len(curve)
@@ -80,7 +80,7 @@ Curve
 
 Use the `.plot()` method to visualize the data. This requires [matplotlib](https://matplotlib.org/) to be installed:
 
-```python
+```pycon
 >>> fig = curve.plot() # (1)!
 >>> fig.show()
 ```
@@ -93,7 +93,7 @@ The resulting plot looks like this:
 
 The measurement stores a single peak. You can retrieve it using:
 
-```python
+```pycon
 >>> curve.peaks
 >>> peaks
 [Peak(x=0.179102 V, y=3.42442 µA, y_offset=0.26371 µA, area=0.818265 VµA, width=0.221563 V)]
@@ -101,7 +101,7 @@ The measurement stores a single peak. You can retrieve it using:
 
 To programmatically find peaks, use `.find_peaks()`:
 
-```python
+```pycon
 >>> peaks = curve.find_peaks()
 >>> peaks
 [Peak(x=0.179102 V, y=3.42442 µA, y_offset=0.26371 µA, area=0.818265 VµA, width=0.221563 V)]
@@ -116,13 +116,13 @@ Alternatively, for Cyclic Voltammetry (CV) and Linear Sweep Voltammetry (LSV), y
 
 You can also filter data using [pypalmsens.data.Curve.smooth][]. Note that this method updates the curve in-place:
 
-```python
+```pycon
 >>> curve.smooth(smooth_level=1)
 ```
 
 Or, you can use a [Savitsky-Golay filter](https://en.wikipedia.org/wiki/Savitzky%E2%80%93Golay_filter):
 
-```python
+```pycon
 >>> curve.savitsky_golay(window_size=3)
 ```
 
@@ -130,7 +130,7 @@ Curve data are devived from the underlying [Dataset](#dataset), where variable d
 To access the raw x and y data for custom plotting or analysis, use `curve.x_array` and `curve.y_array`.
 Both return [DataArray](#dataarray) objects that can be converted to standard Python floats or numpy arrays:
 
-```python
+```pycon
 >>> curve.x_array
 DataArray(name=potential, unit=V, n_points=219)
 >>> list(curve.x_array)
@@ -149,7 +149,7 @@ For more details on array manipulation, see [pypalmsens.data.Curve][].
 [Peak][pypalmsens.data.Peak] is a small dataclass containing peak properties.
 Stored peaks can be retrieved from a [Curve](#curve) (for example, if PSTrace stored peaks in the `.pssession` file):
 
-```python
+```pycon
 >>> peaks = curve.peaks
 >>> peaks
 [Peak(x=0.179102 V, y=3.42442 µA, y_offset=0.26371 µA, area=0.818265 VµA, width=0.221563 V)]
@@ -157,7 +157,7 @@ Stored peaks can be retrieved from a [Curve](#curve) (for example, if PSTrace st
 
 Many peak properties are accessible from this object:
 
-```python
+```pycon
 >>> peak.x, peak.y
 (0.179102, 3.42442)
 >>> peak.width
@@ -178,7 +178,7 @@ For more information on peak properties, see [pypalmsens.data.Peak][].
 
 Raw data are stored in a [DataSet](#dataset). The dataset contains all raw measurement data, including the data for the curves.
 
-```python
+```pycon
 >>> dataset = measurement.dataset
 >>> dataset
 DataSet(['Time', 'Potential', 'Current'])
@@ -186,7 +186,7 @@ DataSet(['Time', 'Potential', 'Current'])
 
 Since a `DataSet` acts like a Python dictionary (a mapping), you can access arrays by name:
 
-```python
+```pycon
 >>> dataset['Time']
 DataArray(name=time, unit=s, n_points=219)
 >>> dataset['Potential']
@@ -195,7 +195,7 @@ PotentialArray(name=potential, unit=V, n_points=219)
 
 To list all available arrays:
 
-```python
+```pycon
 >>> dataset.arrays()
 [DataArray(name=time, unit=s, n_points=219),
  PotentialArray(name=potential, unit=V, n_points=219),
@@ -204,7 +204,7 @@ To list all available arrays:
 
 You can retrieve arrays of a specific type using:
 
-```python
+```pycon
 >>> dataset.array_types
 {'Current', 'Potential', 'Time'}
 >>> dataset.arrays(type='Current')
@@ -213,7 +213,7 @@ You can retrieve arrays of a specific type using:
 
 Alternatively, you can query by name:
 
-```python
+```pycon
 >>> dataset.array_names
 {'current', 'potential', 'time'}
 >>> dataset.arrays(name='time')
@@ -222,7 +222,7 @@ Alternatively, you can query by name:
 
 You can also filter by quantity:
 
-```python
+```pycon
 >>> dataset.array_quantities
 {'Current', 'Potential', 'Time'}
 >>> dataset.arrays(quantity='Potential')
@@ -236,7 +236,7 @@ Note that for larger datasets, these methods might return multiple `DataArray` o
 
 If you have [pandas](https://pandas.pydata.org/) installed, you can easily convert the entire dataset into a [DataFrame](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html):
 
-```python
+```pycon
 >>> df = pd.DataFrame(dataset.to_dict())
 >>> df
      Time Potential   Current     CR ReadingStatus
@@ -253,7 +253,7 @@ If you have [pandas](https://pandas.pydata.org/) installed, you can easily conve
 
 Any new [Curve](#curve) can be generated by passing the desired x and y keys:
 
-```python
+```pycon
 >>> list(dataset)
 ['Time', 'Potential', 'Current']
 >>> curve = dataset.curve(x='Time', y='Potential', title='My curve')
@@ -270,7 +270,7 @@ A [Dataset](#dataset) contains multiple data arrays.
 
 Let's examine the first current array:
 
-```python
+```pycon
 >>> array = dataset.arrays(type='Current')[0]
 >>> array
 CurrentArray(name=current, unit=µA, n_points=219)
@@ -278,7 +278,7 @@ CurrentArray(name=current, unit=µA, n_points=219)
 
 An array stores metadata about itself:
 
-```python
+```pycon
 >>> array.name
 'current'
 >>> array.type
@@ -291,7 +291,7 @@ An array stores metadata about itself:
 
 Arrays behave like a Python [Sequence](https://docs.python.org/3/glossary.html#term-sequence) (e.g., a list):
 
-```python
+```pycon
 >>> len(array)
 219
 >>> min(array)
@@ -304,7 +304,7 @@ Arrays behave like a Python [Sequence](https://docs.python.org/3/glossary.html#t
 
 Arrays support complex slicing, but remember that this operation returns a standard Python list:
 
-```python
+```pycon
 >>> array[:5]
 [0.352146, 0.351192, 0.3469, 0.345947, 0.344516]
 >>> array[-5:]
@@ -317,7 +317,7 @@ Arrays support complex slicing, but remember that this operation returns a stand
 
 You can convert arrays into lists or numpy arrays:
 
-```python
+```pycon
 >>> list(array)
 [0.352146, 0.351192, ..., 0.19908, 0.199557]
 >>> np.array(array)
@@ -330,7 +330,7 @@ For more information on array structures, see [pypalmsens.data.DataArray][].
 
 `CurrentArray` derives from `DataArray` and includes additional methods for analyzing current readings, such as the current range, reading status, etc.:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 >>> measurement = ps.measure(ps.CyclicVoltammetry())
 >>> array = measurement['Current']
@@ -366,7 +366,7 @@ For more information, see [pypalmsens.data.CurrentArray][].
 
 Similar to currents, `PotentialArray` also derives from `DataArray` and provides methods to query associated data:
 
-```python
+```pycon
 >>> array = measurement.dataset['Potential']
 >>> array.potential()  # (1)!
 [-0.50, -0.40, 0.30, ...]
@@ -401,7 +401,7 @@ You can retrieve impedance data from an impedance (EIS/GEIS) measurement.
 Since an EIS measurement might be multichannel, `.eis_data` returns a list of results.
 If you are not using a multiplexer, you can select the first (and only) item from this list:
 
-```python
+```pycon
 >>> eis_measurement = measurements[2]
 >>> eis_measurement
 Measurement(title=Impedance Spectroscopy [2], timestamp=12-Jul-17 14:48:42, device=PalmSens4)
@@ -415,7 +415,7 @@ Measurement(title=Impedance Spectroscopy [2], timestamp=12-Jul-17 14:48:42, devi
 
 The `EISData` object can be queried for metadata:
 
-```python
+```pycon
 >>> eis.title
 'FixedPotential at 71 freqs [2]'
 >>> eis.scan_type
@@ -430,7 +430,7 @@ The `EISData` object can be queried for metadata:
 
 If you previously fitted a circuit model in PSTrace, you can retrieve the CDC values:
 
-```python
+```pycon
 >>> eis_data.cdc
 'R([RT]Q)'
 >>> eis_data.cdc_values
@@ -439,7 +439,7 @@ If you previously fitted a circuit model in PSTrace, you can retrieve the CDC va
 
 You can use these values to [fit a circuit model](circuit_fitting.md):
 
-```python
+```pycon
 >>> model = ps.fitting.CircuitModel(cdc=eis_data.cdc)
 >>> result = model.fit(eis_data, parameters=eis_data.cdc_values)
 >>> result
@@ -455,14 +455,14 @@ FitResult(
 
 The raw data can be accessed via `.dataset`, which returns a [DataSet](#dataset) object:
 
-```python
+```pycon
 >>> eis_data.dataset
 DataSet(['Current', 'Potential', 'Time', 'Frequency', 'ZRe', 'ZIm', 'Z', 'Phase', 'Iac', 'Unspecified_1', 'Unspecified_2', 'Unspecified_3', 'Unspecified_4', 'YRe', 'YIm', 'Y', 'Cs', 'CsRe', 'CsIm'])
 ```
 
 You can retrieve all arrays from the EIS data:
 
-```python
+```pycon
 >>> eis_data.arrays()
 [CurrentArray(name=Idc, unit=µA, n_points=71),
  PotentialArray(name=potential, unit=V, n_points=71),
@@ -479,7 +479,7 @@ For more information on EIS datasets, see [pypalmsens.data.EISData][].
 
 If an EIS dataset contains subscans, this will be shown in the object's representation:
 
-```python
+```pycon
 >>> eis
 EISData(title=CH 3: E dc scan at 5 freqs, n_points=20, n_frequencies=5, n_subscans=4)
 >>> eis.has_subscans
@@ -490,7 +490,7 @@ True
 
 Subscans can be accessed via the `.subscans()` method:
 
-```python
+```pycon
 >>> eis.subscans
 [EISData(title=E=0.000 V, n_points=5, n_frequencies=5),
  EISData(title=E=0.200 V, n_points=5, n_frequencies=5),

--- a/python/docs/zensical/files.md
+++ b/python/docs/zensical/files.md
@@ -6,7 +6,7 @@ pypalmsens and PSTrace store measurements and their corresponding methods in `.p
 
 [pypalmsens.load_method_file][] is used to load method files (with the `.psmethod` extension). This returns a [Technique](./reference/methods/index.md) object containing all technique parameters.
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> method = ps.load_method_file('PSDummyCell_LSV.psmethod')
@@ -24,7 +24,7 @@ LinearSweepVoltammetry(
 
 Save the method using [pypalmsens.save_method_file][]. The `.psmethod` file can be opened with PSTRace.
 
-```python
+```pycon
 >>> ps.save_method_file(method, 'lsv.psmethod')
 ```
 
@@ -36,7 +36,7 @@ Measurement data can be loaded from `.pssession` files. This contains one or mor
 
 For example, loading a collection of measurements from a session file and showing the first one:
 
-```python
+```pycon
 >>> from pypalmsens import load_session_file
 
 >>> measurement = load_session_file('my_measurement.pssession')[0]
@@ -56,7 +56,7 @@ See the [Measurement documentation](../data.md#measurement) for how to work with
 
 Likewise, save your data using [pypalmsens.save_session_file][]. Note that session files can contain multiple measurements, therefore
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> measurement = ps.measure(ps.CyclicVoltammetry())

--- a/python/docs/zensical/index.md
+++ b/python/docs/zensical/index.md
@@ -28,8 +28,8 @@ With PyPalmSens, you can:
 
 To install:
 
-```bash
-pip install pypalmsens
+```console
+$ pip install pypalmsens
 ```
 
 PyPalmSens works on Windows, MacOS, and Linux (including ARM-based single-board computers like Raspberry Pi).
@@ -41,7 +41,7 @@ Since PyPalmSens is built on top of the [PalmSens .NET libraries](https://dev.pa
 
 The following example shows how to set up and measure a simple chronoamperometry experiment:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> method = ps.ChronoAmperometry(

--- a/python/docs/zensical/js/extra.js
+++ b/python/docs/zensical/js/extra.js
@@ -1,0 +1,55 @@
+// Adapted from: https://github.com/astral-sh/uv/pull/5397
+
+function cleanupClipboardText(targetSelector) {
+  const targetElement = document.querySelector(targetSelector);
+
+  // exclude "Generic Prompt" and "Generic Output" spans from copy
+  const excludedClasses = ["gp", "go"];
+
+  const clipboardText = Array.from(targetElement.childNodes)
+    .filter(
+      (node) =>
+        !excludedClasses.some((className) =>
+          node?.classList?.contains(className),
+        ),
+    )
+    .map((node) => node.textContent)
+    .filter((s) => s != "");
+  return clipboardText.join("").trim();
+}
+
+// Sets copy text to attributes lazily using an Intersection Observer.
+function setCopyText() {
+  // The `data-clipboard-text` attribute allows for customized content in the copy
+  // See: https://www.npmjs.com/package/clipboard#copy-text-from-attribute
+  const attr = "clipboardText";
+  // all "copy" buttons whose target selector is a <code> element
+  const elements = document.querySelectorAll(
+    'button[data-clipboard-target$="code"]',
+  );
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      // target in the viewport that have not been patched
+      if (
+        entry.intersectionRatio > 0 &&
+        entry.target.dataset[attr] === undefined
+      ) {
+        entry.target.dataset[attr] = cleanupClipboardText(
+          entry.target.dataset.clipboardTarget,
+        );
+      }
+    });
+  });
+
+  elements.forEach((elt) => {
+    observer.observe(elt);
+  });
+}
+
+// Using the document$ observable is particularly important if you are using instant loading since
+// it will not result in a page refresh in the browser
+// See `How to integrate with third-party JavaScript libraries` guideline:
+// https://squidfunk.github.io/mkdocs-material/customization/?h=javascript#additional-javascript
+document$.subscribe(function () {
+  setCopyText();
+});

--- a/python/docs/zensical/reference/corrosion/index.md
+++ b/python/docs/zensical/reference/corrosion/index.md
@@ -13,7 +13,7 @@ The techniques below are identical to the other [electrochemistry techniques](..
 
 For example to set up a CP experiment:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> method = ps.CyclicPolarization(

--- a/python/docs/zensical/reference/energy/index.md
+++ b/python/docs/zensical/reference/energy/index.md
@@ -19,7 +19,7 @@ These methods are only available in PyPalmSens.
 
 For example to set up a battery cycling experiment:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> method = ps.experimental_BatteryCycling(

--- a/python/docs/zensical/reference/filesystem.md
+++ b/python/docs/zensical/reference/filesystem.md
@@ -4,7 +4,7 @@ Some PalmSens devices, like the EmStat 4, EmStat Pico, Sensit Wearable, and Nexu
 
 Example:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> with ps.connect() as manager:

--- a/python/docs/zensical/reference/instrument.md
+++ b/python/docs/zensical/reference/instrument.md
@@ -4,7 +4,7 @@ Use the `InstrumentManager()` to start experiments and control your PalmSens ins
 
 The most high-level way to start a measurement is to use the `measure()` function:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> method = ps.CyclicVoltammetry()
@@ -13,7 +13,7 @@ The most high-level way to start a measurement is to use the `measure()` functio
 
 You can also manage the connection yourself, using `connect()`, for example:
 
-```python
+```pycon
 >>> with ps.connect() as manager:
 ...    method = ps.ChronoAmperometry()
 ...    measurement = manager.measure(method)
@@ -21,7 +21,7 @@ You can also manage the connection yourself, using `connect()`, for example:
 
 Or using `InstrumentManager()` directly as a context manager:
 
-```python
+```pycon
 >>> instruments = discover()
 
 >>> with ps.InstrumentManager(instruments[0]) as manager:
@@ -30,7 +30,7 @@ Or using `InstrumentManager()` directly as a context manager:
 
 Or managing the instrument connection yourself:
 
-```python
+```pycon
 >>> instruments = discover()
 
 >>> manager = ps.InstrumentManager(instruments[0])

--- a/python/docs/zensical/reference/instrument_async.md
+++ b/python/docs/zensical/reference/instrument_async.md
@@ -9,7 +9,7 @@ This means you have to use the await/async expressions to manage the event loop.
 
 For example, to start a measurement:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> method = ps.CyclicVoltammetry()
@@ -18,7 +18,7 @@ For example, to start a measurement:
 
 Or to manage the connection yourself:
 
-```python
+```pycon
 >>> async with await ps.connect_async() as manager:
 ...     method = ps.ChronoAmperometry()
 ...     measurement = await manager.measure(method)
@@ -26,7 +26,7 @@ Or to manage the connection yourself:
 
 Or using `InstrumentManagerAsync()` directly as a context manager:
 
-```python
+```pycon
 >>> instruments = await discover_async()
 
 >>> async with ps.InstrumentManagerAsync(instruments[0]) as manager:
@@ -35,7 +35,7 @@ Or using `InstrumentManagerAsync()` directly as a context manager:
 
 Or managing the instrument connection yourself:
 
-```python
+```pycon
 >>> instruments = await discover_async()
 
 >>> manager = ps.InstrumentManagerAsync(instruments[0])

--- a/python/docs/zensical/reference/methods/index.md
+++ b/python/docs/zensical/reference/methods/index.md
@@ -4,7 +4,7 @@ This section contains a listing of all available techniques in PyPalmSens.
 
 For example to set up a [CV][pypalmsens.CyclicVoltammetry] experiment:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> method = ps.CyclicVoltammetry(

--- a/python/docs/zensical/reference/methods/settings.md
+++ b/python/docs/zensical/reference/methods/settings.md
@@ -6,7 +6,7 @@ There are two ways to adjust these settings, either via the method constructor.
 
 For example, adjusting the post measurement settings:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> cv = ps.LinearSweepVoltammetry(
@@ -23,7 +23,7 @@ For example, adjusting the post measurement settings:
 
 Or by setting the values on the attribute:
 
-```python
+```pycon
 >>> lsv = ps.LinearSweepVoltammetry()
 
 >>> lsv.post_measurement.cell_on_after_measurement = True

--- a/python/docs/zensical/releases/index.md
+++ b/python/docs/zensical/releases/index.md
@@ -100,7 +100,7 @@ This release adds support for corrosion methods to PyPalmSens. This is mostly a 
 You can now retrieve instrument capabilities using [`InstrumentManager.capabilities`](https://dev.palmsens.com/python/latest/_attachments/reference/instrument/#pypalmsens.InstrumentManager.capabilities).
 This provides information on device features, firmware versions, supported current and potential ranges, and other information.
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> with ps.connect() as manager:
@@ -114,7 +114,7 @@ Capabilities(device_type='EmStat4LR', firmware_version=1.5, ...)
 
 Get the estimated measurement duration using [`InstrumentManager.get_estimated_duration()`](https://dev.palmsens.com/python/latest/_attachments/reference/instrument/#pypalmsens.InstrumentManager.get_estimated_duration):
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> method = ps.CyclicVoltammetry()
@@ -181,7 +181,7 @@ This is a relatively small release that adds support for the PalmSens Nexus on W
 
 If you are using a Nexus, you can now connect to it via TCP/IP:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> instrument = ps.Instrument.from_ip('192.168.1.123')
@@ -269,7 +269,7 @@ See [the documentation](https://dev.palmsens.com/python/latest/_attachments/data
 
 New methods on `InstrumentManager(Async)` to get the supported methods and current ranges (https://github.com/palmsens/palmsens-sdk/pull/279). See [the docs](https://dev.palmsens.com/python/latest/_attachments/reference/instrument/#pypalmsens.InstrumentManager.supported_applied_current_ranges) for more information.
 
-```python
+```pycon
 >>> import pypalmsens as ps
 >>> manager = ps.connect()
 >>> manager.supported_methods()
@@ -340,7 +340,7 @@ method = ps.mixed_mode.MixedMode(
 
 This release changes how callbacks work. The callback now receives a dataclass, making it easier to integrate into your workflows. If you use callbacks, this may require small changes to your code. See [the documentation](https://dev.palmsens.com/python/latest/_attachments/measuring/#callback), [the API reference](https://dev.palmsens.com/python/latest/_attachments/reference/data/#pypalmsens.data.CallbackData) or one of [the examples](https://dev.palmsens.com/python/latest/_attachments/examples/) for more information.
 
-```python
+```pycon
 >>> def callback(data):
 ...    print({'start': data.start, 'x': data.x[data.start:], 'y': data.y[data.start:]})
 
@@ -352,7 +352,7 @@ This release changes how callbacks work. The callback now receives a dataclass, 
 
 You can pass register a callback to the instrument manager to get updates from the idle status/current/bipot/aux updates. These are also passed as data classes. You can also use the callback to retrieve data during the pretreatment (conditioning and depositing) phases. See [this example](https://dev.palmsens.com/python/latest/_attachments/examples/#status_callback) or checkout the [documentation](https://dev.palmsens.com/python/latest/_attachments/measuring/#idle_status_updates).
 
-```python
+```pycon
 >>> import pypalmsens as ps
 >>> import asyncio
 
@@ -408,7 +408,7 @@ All values set on the methods are automatically validated, and converted to the 
 
 For example:
 
-```python
+```pycon
 >>> cv = ps.CyclicVoltammetry(scanraet=2.0)
 scanraet
   Extra inputs are not permitted [type=extra_forbidden, input_value=1.0, input_type=float]
@@ -445,7 +445,7 @@ A list of allowed values is available via:
 
 Thanks to how the methods are validated, a warning will be raised if an incorrect value is passed:
 
-```python
+```pycon
 >>> ps.CyclicVoltammetry(current_range={'start':'fail'})
 ValidationError: 1 validation error for CyclicVoltammetry
 current_range.start
@@ -474,7 +474,7 @@ The goal for this release is to remove friction when you are getting started wit
 
 We added a new top-level function `measure()` (and `measure_async()`) which will connect to the USB device and start a measurement:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 
 >>> method = ps.ChronoAmperometry(
@@ -491,14 +491,14 @@ Measurement(title=Chronoamperometry, timestamp=17-Nov-25 13:42:16, device=EmStat
 
 The measure function takes a callback as an argument, so you can use this cool one-liner to impress your friends:
 
-```python
+```pycon
 >>> import pypalmsens as ps
 >>> ps.measure(ps.CyclicVoltammetry(), callback=print)
 ```
 
 This change also affects all other `measure()` methods, like `InstrumentManager.measure()` and `InstrumentPool.measure()`.
 
-```python
+```pycon
 >>> ...
 >>> with ps.connect() as manager:
 ...     measurement = manager.measure(method, callback=new_data_callback)

--- a/python/docs/zensical/stylesheets/extra.css
+++ b/python/docs/zensical/stylesheets/extra.css
@@ -85,3 +85,8 @@ html .md-footer-meta.md-typeset a:not(:focus, :hover) {
 .md-copyright {
     color: #FFFFFF70;
 }
+
+/* Don't copy >>> in python code blocks*/
+.highlight .gp, .highlight .go { /* Generic.Prompt, Generic.Output */
+  user-select: none;
+}

--- a/python/zensical.toml
+++ b/python/zensical.toml
@@ -79,7 +79,6 @@ nav = [
   { "Issues ↗" = "https://github.com/palmsens/palmsens-sdk/issues" },
 ]
 
-
 extra_css = [
     # Include a copy of mkdocstrings.css
     # This is a work-around for Antora not publishing
@@ -91,6 +90,7 @@ extra_css = [
 
 extra_javascript = [
   "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js",
+  "js/extra.js",
 ]
 
 [project.extra]


### PR DESCRIPTION
This PR ensures that >>> and any output lines cannot be selected in code blocks, and that they are removed from the `copy to clipboard` function. This helps to make the code blocks be more copy/pastable.

```pycon
>>> print('hello world!')
hello world
```

```console
$ echo 'hello world'
hello world
```

Note that code blocks must be configured as `pycon` or `console` for this to work