### PR TITLE
Re-raise .NET exception as FileNotFound

### DIFF
--- a/python/src/pypalmsens/_io.py
+++ b/python/src/pypalmsens/_io.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import PalmSens
+import System
 from System.IO import MemoryStream, StreamReader, StreamWriter
 from System.Text import Encoding
 
@@ -59,8 +60,11 @@ def load_session_file(
 
     session = PalmSens.Data.SessionManager()
 
-    with stream_reader(str(path)) as stream:
-        session.Load(stream.BaseStream, str(path))
+    try:
+        with stream_reader(str(path)) as stream:
+            session.Load(stream.BaseStream, str(path))
+    except System.IO.FileNotFoundException as exc:
+        raise FileNotFoundError(exc.Message) from exc
 
     session.MethodForEditor.MethodFilename = str(path.absolute())
 
@@ -144,11 +148,14 @@ def save_measurement(path: str | Path, measurement: Measurement):
 def _load_method_file(path: str | Path) -> Method:
     path = Path(path)
 
-    with stream_reader(str(path)) as stream:
-        if path.suffix == PalmSens.DataFiles.MethodFile2.FileExtension:
-            psmethod = PalmSens.DataFiles.MethodFile2.FromStream(stream)
-        else:
-            psmethod = PalmSens.DataFiles.MethodFile.FromStream(stream, str(path))
+    try:
+        with stream_reader(str(path)) as stream:
+            if path.suffix == PalmSens.DataFiles.MethodFile2.FileExtension:
+                psmethod = PalmSens.DataFiles.MethodFile2.FromStream(stream)
+            else:
+                psmethod = PalmSens.DataFiles.MethodFile.FromStream(stream, str(path))
+    except System.IO.FileNotFoundException as exc:
+        raise FileNotFoundError(exc.Message) from exc
 
     psmethod.MethodFilename = str(path.absolute())
 

--- a/python/tests/test_io.py
+++ b/python/tests/test_io.py
@@ -33,6 +33,11 @@ def test_save_load_session(tmpdir, measurement_dpv):
     assert measurement_dpv.device == measurement_dpv2.device
 
 
+def test_load_session_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        _ = ps.load_method_file('foo.bar')
+
+
 def test_save_load_measurement(tmpdir, measurement_dpv):
     path = tmpdir / 'test.psmethod'
 
@@ -82,6 +87,11 @@ def test_save_load_method(tmpdir):
             assert v2 == approx(v)
         else:
             assert v == v2
+
+
+def test_load_method_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        _ = ps.load_method_file('foo.bar')
 
 
 def test_serialize():


### PR DESCRIPTION
This is a small PR that catches .NET System.IO.FileNotFoundException and raises it as Python FileNotFoundError. This makes the error message clearer and the exception easier to catch, if needed.