### PR TITLE
Set encoding for stream reader to Encoding.Unicode (UTF-16LE)

### DIFF
--- a/python/src/pypalmsens/_instruments/comm_protocol.py
+++ b/python/src/pypalmsens/_instruments/comm_protocol.py
@@ -290,7 +290,7 @@ class CommProtocol:
         if not end:
             try:
                 func, *_ = command.split(maxsplit=1)
-            except IndexError:
+            except ValueError:
                 func = ''
 
             end = NEWLINE_TERMINATORS.get(func, '\n')

--- a/python/src/pypalmsens/_instruments/comm_protocol_async.py
+++ b/python/src/pypalmsens/_instruments/comm_protocol_async.py
@@ -264,7 +264,7 @@ class CommProtocolAsync:
         if not end:
             try:
                 func, *_ = command.split(maxsplit=1)
-            except IndexError:
+            except ValueError:
                 func = ''
 
             end = NEWLINE_TERMINATORS.get(func, '\n')

--- a/python/src/pypalmsens/_io.py
+++ b/python/src/pypalmsens/_io.py
@@ -149,7 +149,7 @@ def _load_method_file(path: str | Path) -> Method:
     path = Path(path)
 
     try:
-        with stream_reader(str(path), encoding=Encoding.Unicode) as stream:
+        with stream_reader(str(path), encoding=Encoding.UTF8) as stream:
             if path.suffix == PalmSens.DataFiles.MethodFile2.FileExtension:
                 psmethod = PalmSens.DataFiles.MethodFile2.FromStream(stream)
             else:

--- a/python/src/pypalmsens/_io.py
+++ b/python/src/pypalmsens/_io.py
@@ -61,7 +61,7 @@ def load_session_file(
     session = PalmSens.Data.SessionManager()
 
     try:
-        with stream_reader(str(path)) as stream:
+        with stream_reader(str(path), encoding=Encoding.Unicode) as stream:
             session.Load(stream.BaseStream, str(path))
     except System.IO.FileNotFoundException as exc:
         raise FileNotFoundError(exc.Message) from exc
@@ -96,7 +96,7 @@ def save_session_file(path: str | Path, measurements: Sequence[Measurement]):
     for measurement in measurements:
         session.AddMeasurement(measurement._psmeasurement)
 
-    with stream_writer(str(path), False, Encoding.Unicode) as stream:
+    with stream_writer(str(path), append=False, encoding=Encoding.Unicode) as stream:
         session.Save(stream.BaseStream, str(path))
 
 
@@ -149,7 +149,7 @@ def _load_method_file(path: str | Path) -> Method:
     path = Path(path)
 
     try:
-        with stream_reader(str(path)) as stream:
+        with stream_reader(str(path), encoding=Encoding.Unicode) as stream:
             if path.suffix == PalmSens.DataFiles.MethodFile2.FileExtension:
                 psmethod = PalmSens.DataFiles.MethodFile2.FromStream(stream)
             else:


### PR DESCRIPTION
This PR is an attempt to fix a decoding error when loading .pssession files:

```
AggregateException: One or more errors occurred. ---> Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: ♦. Path '', line 0, position 0.
```