### PR TITLE
Release python-1.11.0

### DIFF
--- a/docs/sdk/modules/ROOT/pages/releases.adoc
+++ b/docs/sdk/modules/ROOT/pages/releases.adoc
@@ -2,6 +2,7 @@ Releases
 ========
 
 // latest
+- https://github.com/palmsens/palmsens-sdk/releases/tag/python-1.11.0[python-1.11.0]
 - https://github.com/palmsens/palmsens-sdk/releases/tag/python-1.10.1[python-1.10.1]
 - https://github.com/palmsens/palmsens-sdk/releases/tag/python-1.10.0[python-1.10.0]
 - https://github.com/palmsens/palmsens-sdk/releases/tag/python-1.9.0[python-1.9.0]

--- a/python/docs/antora.yml
+++ b/python/docs/antora.yml
@@ -1,5 +1,5 @@
 name: python
-version: '1.10.1'
+version: '1.11.0'
 title: PyPalmSens
 start_page: index.adoc
 nav:

--- a/python/docs/zensical/filesystem.md
+++ b/python/docs/zensical/filesystem.md
@@ -142,7 +142,7 @@ For more information, see the [pathlib.PurePath][] documentation.
 
 ## Loading Measurements
 
-The most common use case for the device filesystem is loading saved measurements. Use [pypalmsens.DeviceFileSystem.load_measurement][] to load a `.dmeas` file from the device into a [pypalmsans.data.Measurement][] object:
+The most common use case for the device filesystem is loading saved measurements. Use [pypalmsens.DeviceFileSystem.load_measurement][] to load a `.dmeas` file from the device into a [pypalmsens.data.Measurement][] object:
 
 ```pycon
 >>> path = 'Measurements/17-07-2026/LSV-10-00-28-1.dmeas'

--- a/python/docs/zensical/measuring.md
+++ b/python/docs/zensical/measuring.md
@@ -697,7 +697,7 @@ This means the data can be read in any programming language with a JSON parser.
 
 ### Load stream data
 
-PyPalmSens contains a parser to load such files, [pypalmsens.load_stream_file][]. Although the data structure resembles that [pypalmsans.data.Measurement][], it it is much smaller in scope, and lacks some of the more advanced features.
+PyPalmSens contains a parser to load such files, [pypalmsens.load_stream_file][]. Although the data structure resembles that [pypalmsens.data.Measurement][], it it is much smaller in scope, and lacks some of the more advanced features.
 
 ```pycon
 >>> import pypalmsens as ps
@@ -723,7 +723,7 @@ CurveMetadata(title='CV i vs E Scan 1', columns=['x', 'y'], units=['V', 'µA'], 
  [-0.300033, -29.950316],
  [-0.400011, -40.018056]]
 
- ```
+```
 
 ### Data format
 

--- a/python/docs/zensical/reference/io.md
+++ b/python/docs/zensical/reference/io.md
@@ -7,6 +7,7 @@ This page contains a listing of all functions to load and save `.pssession` and 
 - [`pypalmsens.load_measurement`][pypalmsens.load_measurement]
 - [`pypalmsens.load_method_file`][pypalmsens.load_method_file]
 - [`pypalmsens.load_session_file`][pypalmsens.load_session_file]
+- [`pypalmsens.load_stream_file`][pypalmsens.load_stream_file]
 - [`pypalmsens.save_measurement`][pypalmsens.save_measurement]
 - [`pypalmsens.save_method_file`][pypalmsens.save_method_file]
 - [`pypalmsens.save_session_file`][pypalmsens.save_session_file]
@@ -14,6 +15,7 @@ This page contains a listing of all functions to load and save `.pssession` and 
 ::: pypalmsens.load_measurement
 ::: pypalmsens.load_method_file
 ::: pypalmsens.load_session_file
+::: pypalmsens.load_stream_file
 ::: pypalmsens.save_measurement
 ::: pypalmsens.save_method_file
 ::: pypalmsens.save_session_file

--- a/python/docs/zensical/releases/index.md
+++ b/python/docs/zensical/releases/index.md
@@ -1,6 +1,173 @@
 # Changelog
 
 <!-- Latest-->
+## PyPalmSens 1.11.0
+
+> :fontawesome-brands-github: <a href="https://github.com/palmsens/palmsens-sdk/releases/tag/python-1.11.0">python-1.11.0</a>
+| :fontawesome-brands-python: <a href="https://pypi.org/project/pypalmsens/1.11.0">pypalmsens-1.11.0</a>
+| :fontawesome-solid-calendar: 2026-08-14
+
+This is a fairly large release that adds better support for interacting with low level device features. 1.11 adds support for communicating querying the device via the communications protocol and manipulating the internal storage of the device.
+
+Event handling was also significantly expanded. You can now set callbacks to the many hooks available on the measurement loop.
+
+Finally, this release brings new functions for saving/loading data, as well as many small bug fixes and improvements.
+
+### Event handling
+
+This release greatly improves support for event handling. These can be used, for example, to update plots, stream data to a file, or manage progress updates. You can attach callbacks to many measurement hooks:
+
+ - `'curve_begin'`
+ - `'curve_end'`
+ - `'curve_new_data'`
+ - `'eis_data_begin'`
+ - `'eis_data_end'`
+ - `'eis_new_data'`
+ - `'measurement_begin'`
+ - `'measurement_end'`
+ - `'measurement_setup'`
+ - `'measurement_teardown'`
+ - `'receive_message'`
+ - `'receive_status'`
+ - `'error'`
+
+ All of these can be accessed via [`InstrumentManager.on()`][pypalmsens.InstrumentManager.on] or convenience functions such as [`InstrumentManager.on_new_data`][pypalmsens.InstrumentManager.on_curve_new_data]. For example:
+
+```python
+import pypalmsens as ps
+
+with ps.connect() as manager:
+    handle = ps.on_curve_new_data(print)
+    manager.measure(ps.CyclicVoltammetry())
+    handle.cancel()
+```
+
+See the [event event handling documentation](https://dev.palmsens.com/python/latest/_attachments/events/) for more information.
+
+### Loading and saving data
+
+[`load_measurement()`][pypalmsens.load_measurement] and [`save_measurement()`][pypalmsens.save_measurement] are wrappers around load/save_session_file, that
+make it more convenient to work with single measurements.
+
+```pycon
+>>> measurement = ps.load_measurement('cv.pssession')
+>>> ps.save_measurement('cv_copy.pssession', measurement)
+```
+
+You can now also load data from the data stream added in [version 1.10](https://dev.palmsens.com/python/latest/_attachments/releases/#pypalmsens-110).
+Use [`pypalmsens.load_stream_file()`][pypalmsens.load_stream_file] to load such files. The resulting data structure resembles that [`pypalmsens.data.Measurement`][pypalmsens.data.Measurement], but it is much smaller in scope, and lacks some of the more advanced features.
+
+See the [documentation](https://dev.palmsens.com/python/latest/_attachments/measuring/#load-stream-data) for more information.
+
+### Internal storage
+
+This release adds an interface to read, manage, load, remove files from the internal storage on supported PalmSens devices.
+
+Three new classes were added to the api:
+
+- [`pypalmsens.DeviceFileSystem`][pypalmsens.DeviceFileSystem]
+- [`pypalmsens.DeviceFileSystemAsync`][pypalmsens.DeviceFileSystemAsync]
+- [`pypalmsens.DevicePath`][pypalmsens.DevicePath]
+
+For example, to download a measurement off the device:
+
+```pycon
+>>> import pypalmsens as ps
+>>> instrument, _* = ps.discover()
+
+>>> with ps.DeviceFileSystem(instrument) as fs:
+...     files = list(fs.listdir())
+...     path = files[0]
+...     measurement = fs.load_measurement(path)
+
+>>> files
+[DevicePath('Measurements/04-08-2026/LSV-16-02-20-0.dmeas'),
+ DevicePath('Measurements/04-08-2026/LSV-16-06-26-0.dmeas'),
+ DevicePath('Measurements/04-08-2026/LSV-16-06-47-0.dmeas'),
+ ...]
+
+>>> measurement
+Measurement(title=Linear Sweep Voltammetry, timestamp=0001-01-01T00:00:00, device=EmStat4LR)
+
+```
+
+See the [Internal storage documentation](https://dev.palmsens.com/python/latest/_attachments/events/) for more information.
+
+
+### Comm protocol
+
+This release adds a communication interface class to write / read directly to the device using the [Communication protocol](https://dev.palmsens.com/comm_es4/latest/comm/comm_main.html#ch_crc_examples). You can use the Communication protocol to directly query/manipulate the state of your device, e.g. setting registers, file operations, and sending scripts.
+
+Two new classes were added to the api:
+
+- [`pypalmsens.CommProtocol`][pypalmsens.CommProtocol]
+- [`pypalmsens.CommProtocolAsync`][pypalmsens.CommProtocolAsync]
+
+For example, to query the firmware version string:
+
+```pycon
+>>> import pypalmsens as ps
+>>> instrument, *_ = ps.discover()
+>>> with ps.CommProtocol(instrument) as comm:
+>>>     result = comm.query('t')
+>>> result
+'es4_lr1500#Mar 12 2026 14:28:01\nR*'  # Firmware version
+```
+
+Or send methodscript:
+
+```pycon
+>>> script = 'send_string "Hello world!"'
+>>> with ps.CommProtocol(instrument) as comm:
+>>>     result = comm.run_methodscript(script)
+>>> result
+'THello world!\n'
+```
+
+A high level [`query()`][pypalmsens.InstrumentManager.query] method is available on the [`InstrumentManager`][pypalmsens.InstrumentManager], for example:
+
+```pycon
+>>> with ps.connect() as manager:
+>>>     result = manager.query('i')
+>>> result
+'ES4LR20B0008'  # serial number
+```
+
+See the [Communication protocol documentation](https://dev.palmsens.com/python/latest/_attachments/events/) for more information.
+
+
+### MethodSCRIPT
+
+Support for MethodSCRIPT improved as well. Scripts are now validated, so using keywords that do not exist will raise a SyntaxError:
+
+```pycon
+>>> import pypalmsens as ps
+>>> ps.MethodScript(script='foo')
+SyntaxError: line 1:0: mismatched input 'foo' expecting {<EOF>, 'var', 'array', ...}
+```
+
+### What's changed
+
+- Fix sampling time and eq time not updating when loading EIS/GEIS methods ([#406](https://github.com/palmsens/palmsens-sdk/pull/406))
+- Add validation for `pypalmsens.MethodScript` scripts ([#400](https://github.com/palmsens/palmsens-sdk/pull/400))
+- Fix type hint typo ([#414](https://github.com/palmsens/palmsens-sdk/pull/414))
+- Support custom units in MethodScript ([#415](https://github.com/palmsens/palmsens-sdk/pull/415))
+- Add metadata export from data models for Battery Cycling dashboard ([#382](https://github.com/palmsens/palmsens-sdk/pull/382))
+- Allow floats to be set in fields for energy methods ([#416](https://github.com/palmsens/palmsens-sdk/pull/416))
+- Small improvements to energy methods compatibility ([#417](https://github.com/palmsens/palmsens-sdk/pull/417))
+- Add reader for data stream ([#418](https://github.com/palmsens/palmsens-sdk/pull/418))
+- Add support for internal storage ([#420](https://github.com/palmsens/palmsens-sdk/pull/420))
+- Add support for PalmSens 4 in `DeviceFileSystem(Async)` ([#424](https://github.com/palmsens/palmsens-sdk/pull/424))
+- Add interface for communication protocol commands ([#425](https://github.com/palmsens/palmsens-sdk/pull/425))
+- Rename internal methods ([#428](https://github.com/palmsens/palmsens-sdk/pull/428))
+- Add event emitter style registration for callbacks ([#409](https://github.com/palmsens/palmsens-sdk/pull/409), [#410](https://github.com/palmsens/palmsens-sdk/pull/410), [#431](https://github.com/palmsens/palmsens-sdk/pull/431))
+- Disable status when idle by default ([#436](https://github.com/palmsens/palmsens-sdk/pull/436))
+- Add save/load_measurement to public api ([#442](https://github.com/palmsens/palmsens-sdk/pull/442))
+- Use sequence unpacking when discovering instruments ([#443](https://github.com/palmsens/palmsens-sdk/pull/443))
+- Re-raise .NET exception as FileNotFound ([#448](https://github.com/palmsens/palmsens-sdk/pull/448))
+- Set encoding for stream reader to Encoding.Unicode (UTF-16LE) ([#449](https://github.com/palmsens/palmsens-sdk/pull/449))
+
+
 ## PyPalmSens 1.10.1
 
 > :fontawesome-brands-github: <a href="https://github.com/palmsens/palmsens-sdk/releases/tag/python-1.10.1">python-1.10.1</a>
@@ -12,6 +179,7 @@ This release fixes a crash in 1.10.0 when importing PyPalmSens.
 ### What's changed
 
 - Add templates to MANIFEST.in ([#403](https://github.com/palmsens/palmsens-sdk/pull/403))
+
 
 ## PyPalmSens 1.10
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 [project]
 name = "PyPalmSens"
-version = "1.10.1"
+version = "1.11.0"
 description = "Python SDK for PalmSens instruments"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -155,7 +155,7 @@ enableTypeIgnoreComments = true
 reportIgnoreCommentWithoutRule = false
 
 [tool.bumpversion]
-current_version = "1.10.1"
+current_version = "1.11.0"
 
 [[tool.bumpversion.files]]
 filename = "src/pypalmsens/__init__.py"

--- a/python/src/pypalmsens/__init__.py
+++ b/python/src/pypalmsens/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from . import _libpalmsens
 
 __sdk_version__: str = _libpalmsens.load()
-__version__ = '1.10.1'
+__version__ = '1.11.0'
 
 from . import (
     corrosion,

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import datetime
 import subprocess as sp
 import sys
-from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
 
@@ -10,8 +10,8 @@ ROOT = Path(__file__).parents[1]
 
 
 def get_latest_tag(component: str = 'python'):
-    cmd = 'git tag --list --sort -creatordate'.split()
-    p = sp.run(cmd, capture_output=True)
+    cmd = ['git', 'tag', '--list', '--sort', '-creatordate']
+    p = sp.run(cmd, capture_output=True, check=True)
     tags = p.stdout.decode().splitlines()
     for line in tags:
         if line.startswith(component):
@@ -24,7 +24,7 @@ def get_latest_tag(component: str = 'python'):
 
 def get_changes_since_tag(tag: str):
     cmd = f'git log {tag}..HEAD --reverse --oneline'.split()
-    p = sp.run(cmd, capture_output=True)
+    p = sp.run(cmd, capture_output=True, check=True)
     lines = p.stdout.decode().splitlines()
     lines = (line.split(maxsplit=1)[1] for line in lines)
 
@@ -52,7 +52,7 @@ def update_python(new_tag: str, new_version: str) -> str:
     previous_tag = get_latest_tag()
     changelog = get_changes_since_tag(previous_tag)
 
-    time = datetime.today()
+    time = datetime.datetime.now(tz=datetime.UTC)
 
     TEMPLATE_CHANGELOG = dedent("""\
     ## PyPalmSens {new_version}
@@ -61,9 +61,10 @@ def update_python(new_tag: str, new_version: str) -> str:
     | :fontawesome-brands-python: <a href="https://pypi.org/project/pypalmsens/{new_version}">pypalmsens-{new_version}</a>
     | :fontawesome-solid-calendar: {time}
 
-    ## What's changed
+    ### What's changed
 
     {changelog}
+
     """)
 
     TEMPLATE_GH_RELEASES = dedent("""\

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -37,7 +37,7 @@ class SDK:
         cmd = ['bump-my-version', 'show', 'current_version']
 
         with self.chdir():
-            p = sp.run(cmd, capture_output=True)
+            p = sp.run(cmd, capture_output=True, check=True)
 
         return p.stdout.decode().strip()
 
@@ -45,7 +45,7 @@ class SDK:
         cmd = ['bump-my-version', 'show', '--increment', component, 'new_version']
 
         with self.chdir():
-            p = sp.run(cmd, capture_output=True)
+            p = sp.run(cmd, capture_output=True, check=True)
 
         new_version = p.stdout.decode().strip()
         return SDK(self.name, new_version)
@@ -69,8 +69,8 @@ class SDK:
 
 
 def commit_file(path: str | Path, message: str):
-    sp.check_call(['git', 'add', f'{path}'])
-    sp.check_call(['git', 'commit', '-m', message])
+    _ = sp.check_call(['git', 'add', f'{path}'])
+    _ = sp.check_call(['git', 'commit', '-m', message])
 
 
 def update_releases(sdk: SDK, commit: bool = False):
@@ -197,7 +197,7 @@ Push additional changes to branch:
 
 Merge PR:
 
-    gh merge $PR --squash
+    gh pr merge $PR --squash
 
 Make new release:
 


### PR DESCRIPTION
This PR prepares for a new release of the python SDK.

- branch: `release-python-1.11.0`
- version: `1.11.0`
- sdk: `python`

# Release notes

PyPalmSens python-1.11.0 is now available on PyPi.

To upgrade: `pip install pypalmsens -U`.

For more information, see [the documentation](https://dev.palmsens.com/python/latest/_attachments/releases/#pypalmsens-1110)

## What's changed

- Retrieve sampling time and eq time from .net object for EIS/GEIS ([#406](https://github.com/palmsens/palmsens-sdk/pull/406))
- Fix links in documentation ([#407](https://github.com/palmsens/palmsens-sdk/pull/407))
- Normalize MATLAB / LabVIEW spelling ([#408](https://github.com/palmsens/palmsens-sdk/pull/408))
- Add validation for MethodScript ([#400](https://github.com/palmsens/palmsens-sdk/pull/400))
- Implement receive message callback on InstrumentManager ([#409](https://github.com/palmsens/palmsens-sdk/pull/409))
- Add `MeasurementEvents` to register callbacks to events ([#410](https://github.com/palmsens/palmsens-sdk/pull/410))
- Rename repo to `palmsens-sdk` ([#411](https://github.com/palmsens/palmsens-sdk/pull/411))
- Fix type hint typo ([#414](https://github.com/palmsens/palmsens-sdk/pull/414))
- Support custom units in MethodScript ([#415](https://github.com/palmsens/palmsens-sdk/pull/415))
- Application note: Battery Cycling dashboard ([#382](https://github.com/palmsens/palmsens-sdk/pull/382))
- Allow floats to be set in fields for energy methods ([#416](https://github.com/palmsens/palmsens-sdk/pull/416))
- Small improvements to energy methods compatibility ([#417](https://github.com/palmsens/palmsens-sdk/pull/417))
- Add reader for data stream ([#418](https://github.com/palmsens/palmsens-sdk/pull/418))
- Add support for internal storage ([#420](https://github.com/palmsens/palmsens-sdk/pull/420))
- Fix typos in internal storage docs ([#422](https://github.com/palmsens/palmsens-sdk/pull/422))
- Add support for PalmSens 4 in `DeviceFileSystem(Async)` ([#424](https://github.com/palmsens/palmsens-sdk/pull/424))
- Add interface for communication protocol commands ([#425](https://github.com/palmsens/palmsens-sdk/pull/425))
- Rename internal methods ([#428](https://github.com/palmsens/palmsens-sdk/pull/428))
- Update ruff to 0.16 in pre-commit config ([#429](https://github.com/palmsens/palmsens-sdk/pull/429))
- Add event emitter style registration for callbacks ([#431](https://github.com/palmsens/palmsens-sdk/pull/431))
- Disable status when idle by default ([#436](https://github.com/palmsens/palmsens-sdk/pull/436))
- Update documentation ([#434](https://github.com/palmsens/palmsens-sdk/pull/434))
- Small fixes to dotnet docs ([#437](https://github.com/palmsens/palmsens-sdk/pull/437))
- Do not copy prompts for pycon/console blocks ([#439](https://github.com/palmsens/palmsens-sdk/pull/439))
- Add sybil/doctest to test markdown docs ([#441](https://github.com/palmsens/palmsens-sdk/pull/441))
- Add save/load_measurement to public api ([#442](https://github.com/palmsens/palmsens-sdk/pull/442))
- Use sequence unpacking when discovering instruments ([#443](https://github.com/palmsens/palmsens-sdk/pull/443))
- Re-raise .NET exception as FileNotFound ([#448](https://github.com/palmsens/palmsens-sdk/pull/448))
- Set encoding for stream reader to Encoding.Unicode (UTF-16LE) ([#449](https://github.com/palmsens/palmsens-sdk/pull/449))

**Full Changelog**: https://github.com/palmsens/palmsens-sdk/compare/python-1.10.1...python-1.11.0

