### PR TITLE
Refactor setting vs OCP parameters

### DIFF
--- a/python/src/pypalmsens/_methods/settings.py
+++ b/python/src/pypalmsens/_methods/settings.py
@@ -140,7 +140,7 @@ class VersusOCP(BaseSettings):
     - `'potential'`: Potential applied during measurement
     """
 
-    potentials: list[OCPFlag] = Field(default_factory=list)
+    potentials: list[OCPFlag] = Field(default_factory=list, strict=False)
     """Define these potentials vs OCP.
 
     Different methods use different values:

--- a/python/src/pypalmsens/_methods/settings.py
+++ b/python/src/pypalmsens/_methods/settings.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from functools import reduce
+from operator import ior
 from typing import Literal
 
 import PalmSens
@@ -117,29 +119,54 @@ class Pretreatment(BaseSettings):
         self.conditioning_time = single_to_double(psmethod.ConditioningTime)
 
 
+OCPFlag = Literal['none', 'vertex1', 'vertex2', 'begin', 'end', 'potential']
+LSVvsOCPMap = {'begin': 1, 'end': 2}
+CVvsOCPMap = {'vertex1': 1, 'vertex2': 2, 'begin': 4}
+ADvsOCPMap = {'potential': 1}
+EISvsOCPMap = {'potential': 1}
+EISvsOCPMap_pgscan = {'begin': 1, 'end': 2}
+
+
 class VersusOCP(BaseSettings):
-    """Set the versus OCP settings."""
+    """Define which potentials to measure versus Open Circuit Potential (OCP).
 
-    mode: int = 0
-    """Set versus OCP mode.
+    Usually, measured potentials refer to the Working Electrode (WE) relative
+    to the Reference Electrode (RE).
+    Use this class to define which potentials (`potentials`) te measure relative
+    to the OCP.
+    To do so, the technique determines the stable OCP value first.
+    This requires measuring the OCP drift until it settles (`stability_criterion`)
+    or times out (`timeout`) before starting with the measurement.
 
-    Possible values:
+    Note that different methods use different values:
 
-    - 0 = disable versus OCP
-    - 1 = vertex 1 potential
-    - 2 = vertex 2 potential
-    - 3 = vertex 1 & 2 potential
-    - 4 = begin potential
-    - 5 = begin & vertex 1 potential
-    - 6 = begin & vertex 2 potential
-    - 7 = begin & vertex 1 & 2 potential
+    - EIS:
+    - AD:
+    - LSV:
+    - CV:
     """
 
-    max_ocp_time: float = 20.0
-    """Maximum OCP time in s."""
+    potentials: list[OCPFlag] = Field(default_factory=list)
+    """Measure these potentials vs OCP.
+
+    - 'begin':
+    - 'end':
+    - 'vertex1':
+    - 'vertex2':
+
+    Leave blank to disable versus OCP measurements.
+    """
+
+    timeout: float = 20.0
+    """Maximum time in s to determine OCP value.
+
+    Set the OCP value when the `timeout` has elapsed.
+    """
 
     stability_criterion: float = 0.0
     """Stability criterion (potential/time) in mV/s.
+
+    Set the OCP value when the drift is lower than the specified value.
 
     If equal to 0 means no stability criterion.
     If larger than 0, then the value is taken as the stability threshold.
@@ -147,14 +174,58 @@ class VersusOCP(BaseSettings):
 
     @override
     def _export(self, psmethod: PalmSens.Method, /):
-        psmethod.OCPmode = self.mode
-        psmethod.OCPMaxOCPTime = self.max_ocp_time
+        method_id = psmethod.MethodID
+
+        if method_id in ('cv',):
+            m = CVvsOCPMap
+        elif method_id in ('eis',):
+            if str(psmethod.ScanType) == 'PGScan':
+                m = EISvsOCPMap_pgscan
+            else:
+                m = EISvsOCPMap
+        elif method_id in ('ad',):
+            m = ADvsOCPMap
+        elif method_id in ('lsv',):
+            m = LSVvsOCPMap
+        else:
+            raise TypeError(f'{method_id} does not support OCP.')
+
+        if self.potentials:
+            mode = reduce(ior, [m[key] for key in self.potentials])
+        else:
+            mode = 0
+
+        psmethod.OCPmode = mode
+        psmethod.OCPMaxOCPTime = self.timeout
         psmethod.OCPStabilityCriterion = self.stability_criterion
 
     @override
     def _import(self, psmethod: PalmSens.Method, /):
-        self.mode = psmethod.OCPmode
-        self.max_ocp_time = single_to_double(psmethod.OCPMaxOCPTime)
+        mode = psmethod.OCPmode
+
+        method_id = psmethod.MethodID
+
+        if method_id in ('cv',):
+            m = CVvsOCPMap
+        elif method_id in ('eis',):
+            if str(psmethod.ScanType) == 'PGScan':
+                m = EISvsOCPMap_pgscan
+            else:
+                m = EISvsOCPMap
+        elif method_id in ('ad',):
+            m = ADvsOCPMap
+        elif method_id in ('lsv',):
+            m = LSVvsOCPMap
+        else:
+            raise TypeError(f'{method_id} does not support OCP.')
+
+        if mode:
+            potentials = [key for key, val in m.items() if (mode & val) == val]
+        else:
+            potentials = []
+
+        self.potentials = potentials  # type: ignore
+        self.timeout = single_to_double(psmethod.OCPMaxOCPTime)
         self.stability_criterion = single_to_double(psmethod.OCPStabilityCriterion)
 
 

--- a/python/src/pypalmsens/_methods/settings.py
+++ b/python/src/pypalmsens/_methods/settings.py
@@ -8,8 +8,6 @@ import PalmSens
 from pydantic import Field
 from typing_extensions import override
 
-from pypalmsens.types import AllowedMethods
-
 from .._converters import (
     cr_enum_to_string,
     cr_string_to_enum,
@@ -122,11 +120,6 @@ class Pretreatment(BaseSettings):
 
 
 OCPFlag = Literal['none', 'vertex1', 'vertex2', 'begin', 'end', 'potential']
-LSVvsOCPMap = {'begin': 1, 'end': 2}
-CVvsOCPMap = {'vertex1': 1, 'vertex2': 2, 'begin': 4}
-ADvsOCPMap = {'potential': 1}
-EISvsOCPMap = {'potential': 1}
-EISvsOCPMap_pgscan = {'begin': 1, 'end': 2}
 
 
 class VersusOCP(BaseSettings):
@@ -173,24 +166,10 @@ class VersusOCP(BaseSettings):
 
     @override
     def _export(self, psmethod: PalmSens.Method, /):
-        method_id: AllowedMethods = psmethod.MethodID
-
-        if method_id in ('cv', 'fcv', 'cp'):
-            m = CVvsOCPMap
-        elif method_id in ('eis', 'fis'):
-            if str(psmethod.ScanType) == 'PGScan':
-                m = EISvsOCPMap_pgscan
-            else:
-                m = EISvsOCPMap
-        elif method_id in ('ad', 'ps', 'fam'):
-            m = ADvsOCPMap
-        elif method_id in ('lsv', 'acv', 'lp', 'swv', 'dpv', 'npv'):
-            m = LSVvsOCPMap
-        else:
-            raise TypeError(f'{method_id} does not support OCP.')
+        ocp_flag_map = self._ocp_flag_map(psmethod)
 
         if self.potentials:
-            mode = reduce(ior, [m[key] for key in self.potentials])
+            mode = reduce(ior, [ocp_flag_map[key] for key in self.potentials])
         else:
             mode = 0
 
@@ -200,32 +179,33 @@ class VersusOCP(BaseSettings):
 
     @override
     def _import(self, psmethod: PalmSens.Method, /):
-        mode = psmethod.OCPmode
+        ocp_flag_map = self._ocp_flag_map(psmethod)
 
-        method_id = psmethod.MethodID
-
-        if method_id in ('cv', 'fcv', 'cp'):
-            m = CVvsOCPMap
-        elif method_id in ('eis', 'fis'):
-            if str(psmethod.ScanType) == 'PGScan':
-                m = EISvsOCPMap_pgscan
-            else:
-                m = EISvsOCPMap
-        elif method_id in ('ad', 'ps', 'fam'):
-            m = ADvsOCPMap
-        elif method_id in ('lsv', 'acv', 'lp', 'swv', 'dpv', 'npv'):
-            m = LSVvsOCPMap
-        else:
-            raise TypeError(f'{method_id} does not support OCP.')
-
-        if mode:
-            potentials = [key for key, val in m.items() if (mode & val) == val]
+        if mode := psmethod.OCPmode:
+            potentials = [key for key, val in ocp_flag_map.items() if (mode & val) == val]
         else:
             potentials = []
 
         self.potentials = potentials  # type: ignore
         self.timeout = single_to_double(psmethod.OCPMaxOCPTime)
         self.stability_criterion = single_to_double(psmethod.OCPStabilityCriterion)
+
+    def _ocp_flag_map(self, psmethod: PalmSens.Method) -> dict[str, int]:
+        method_id = psmethod.MethodID
+
+        if method_id in ('cv', 'fcv', 'cp'):
+            return {'vertex1': 1, 'vertex2': 2, 'begin': 4}
+        elif method_id in ('eis', 'fis'):
+            if str(psmethod.ScanType) == 'PGScan':
+                return {'begin': 1, 'end': 2}
+            else:
+                return {'potential': 1}
+        elif method_id in ('ad', 'ps', 'fam'):
+            return {'potential': 1}
+        elif method_id in ('lsv', 'acv', 'lp', 'swv', 'dpv', 'npv'):
+            return {'begin': 1, 'end': 2}
+
+        raise TypeError(f'{method_id} does not support OCP.')
 
 
 class BiPotCurrentRange(BaseModel):

--- a/python/src/pypalmsens/_methods/settings.py
+++ b/python/src/pypalmsens/_methods/settings.py
@@ -18,6 +18,7 @@ from .._converters import (
 from .._types import (
     AllowedCurrentRanges,
     AllowedPotentialRanges,
+    OCPFlag,
 )
 from .base import BaseSettings
 from .base_model import BaseModel
@@ -117,9 +118,6 @@ class Pretreatment(BaseSettings):
         self.deposition_time = single_to_double(psmethod.DepositionTime)
         self.conditioning_potential = single_to_double(psmethod.ConditioningPotential)
         self.conditioning_time = single_to_double(psmethod.ConditioningTime)
-
-
-OCPFlag = Literal['vertex1', 'vertex2', 'begin', 'end', 'potential']
 
 
 class VersusOCP(BaseSettings):

--- a/python/src/pypalmsens/_methods/settings.py
+++ b/python/src/pypalmsens/_methods/settings.py
@@ -119,20 +119,27 @@ class Pretreatment(BaseSettings):
         self.conditioning_time = single_to_double(psmethod.ConditioningTime)
 
 
-OCPFlag = Literal['none', 'vertex1', 'vertex2', 'begin', 'end', 'potential']
+OCPFlag = Literal['vertex1', 'vertex2', 'begin', 'end', 'potential']
 
 
 class VersusOCP(BaseSettings):
     """Define which potentials to measure versus Open Circuit Potential (OCP).
 
-    Usually, measured potentials refer to the Working Electrode (WE) relative
+    Usually, potentials refer to the Working Electrode (WE) relative
     to the Reference Electrode (RE).
-    Use this class to define which potentials (`potentials`) te measure relative
+    Use this class to define which potentials (`potentials`) are relative
     to the OCP.
 
     To do so, the technique determines the stable OCP value first.
     This requires measuring the OCP drift until it settles (`stability_criterion`)
     or times out (`timeout`) before starting with the measurement.
+
+    The following potentials can be defined relative to OCP:
+
+    - `'vertex1'`, `'vertex2'`: Potential at which the scan direction is reversed
+    - `'begin'`: Potential applied at the beginning of a measurement
+    - `'end'`: Potential applied at the end of a measurement
+    - `'potential'`: Potential applied during measurement
     """
 
     potentials: list[OCPFlag] = Field(default_factory=list)

--- a/python/src/pypalmsens/_methods/settings.py
+++ b/python/src/pypalmsens/_methods/settings.py
@@ -143,7 +143,7 @@ class VersusOCP(BaseSettings):
     """
 
     potentials: list[OCPFlag] = Field(default_factory=list)
-    """Measure these potentials vs OCP.
+    """Define these potentials vs OCP.
 
     Different methods use different values:
 

--- a/python/src/pypalmsens/_methods/settings.py
+++ b/python/src/pypalmsens/_methods/settings.py
@@ -8,6 +8,8 @@ import PalmSens
 from pydantic import Field
 from typing_extensions import override
 
+from pypalmsens.types import AllowedMethods
+
 from .._converters import (
     cr_enum_to_string,
     cr_string_to_enum,
@@ -134,25 +136,22 @@ class VersusOCP(BaseSettings):
     to the Reference Electrode (RE).
     Use this class to define which potentials (`potentials`) te measure relative
     to the OCP.
+
     To do so, the technique determines the stable OCP value first.
     This requires measuring the OCP drift until it settles (`stability_criterion`)
     or times out (`timeout`) before starting with the measurement.
-
-    Note that different methods use different values:
-
-    - EIS:
-    - AD:
-    - LSV:
-    - CV:
     """
 
     potentials: list[OCPFlag] = Field(default_factory=list)
     """Measure these potentials vs OCP.
 
-    - 'begin':
-    - 'end':
-    - 'vertex1':
-    - 'vertex2':
+    Different methods use different values:
+
+    - CV, FCV, CP: `'vertex1'`, `'vertex2'`, `'begin'`
+    - EIS, FIS: `'begin'`, `'end'`
+    - EIS (potential scan): `'potential'`
+    - AD, PS, FAM: `'potential`'
+    - LSV, ACV, LP, SWV, DPV, NPV: `'begin'`, `'end'`
 
     Leave blank to disable versus OCP measurements.
     """
@@ -174,18 +173,18 @@ class VersusOCP(BaseSettings):
 
     @override
     def _export(self, psmethod: PalmSens.Method, /):
-        method_id = psmethod.MethodID
+        method_id: AllowedMethods = psmethod.MethodID
 
-        if method_id in ('cv',):
+        if method_id in ('cv', 'fcv', 'cp'):
             m = CVvsOCPMap
-        elif method_id in ('eis',):
+        elif method_id in ('eis', 'fis'):
             if str(psmethod.ScanType) == 'PGScan':
                 m = EISvsOCPMap_pgscan
             else:
                 m = EISvsOCPMap
-        elif method_id in ('ad',):
+        elif method_id in ('ad', 'ps', 'fam'):
             m = ADvsOCPMap
-        elif method_id in ('lsv',):
+        elif method_id in ('lsv', 'acv', 'lp', 'swv', 'dpv', 'npv'):
             m = LSVvsOCPMap
         else:
             raise TypeError(f'{method_id} does not support OCP.')
@@ -205,16 +204,16 @@ class VersusOCP(BaseSettings):
 
         method_id = psmethod.MethodID
 
-        if method_id in ('cv',):
+        if method_id in ('cv', 'fcv', 'cp'):
             m = CVvsOCPMap
-        elif method_id in ('eis',):
+        elif method_id in ('eis', 'fis'):
             if str(psmethod.ScanType) == 'PGScan':
                 m = EISvsOCPMap_pgscan
             else:
                 m = EISvsOCPMap
-        elif method_id in ('ad',):
+        elif method_id in ('ad', 'ps', 'fam'):
             m = ADvsOCPMap
-        elif method_id in ('lsv',):
+        elif method_id in ('lsv', 'acv', 'lp', 'swv', 'dpv', 'npv'):
             m = LSVvsOCPMap
         else:
             raise TypeError(f'{method_id} does not support OCP.')

--- a/python/src/pypalmsens/_types.py
+++ b/python/src/pypalmsens/_types.py
@@ -138,6 +138,12 @@ AllowedFrequencyTypes = Literal['fixed', 'scan']
 """Possible frequency types."""
 
 
+OCPFlag = Literal['vertex1', 'vertex2', 'begin', 'end', 'potential']
+"""Possible names for potentials defined versus OCP.
+
+See [VersusOCP][pypalmsens.settings.VersusOCP] for details."""
+
+
 class MethodTypeCompatible(Protocol):
     """All methods, including [MethodType][] and those that generate compatible MethodSCRIPT."""
 

--- a/python/src/pypalmsens/types.py
+++ b/python/src/pypalmsens/types.py
@@ -16,6 +16,7 @@ from ._types import (
     AllowedTimingStatus,
     MethodType,
     MethodTypeCompatible,
+    OCPFlag,
 )
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     'AllowedTimingStatus',
     'MethodType',
     'MethodTypeCompatible',
+    'OCPFlag',
 ]

--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -110,17 +110,42 @@ def test_PretreatmentSettings():
     assert new_params == params
 
 
-def test_VersusOcpSettings():
-    obj = Techniques.CyclicVoltammetry()
+@pytest.mark.parametrize(
+    'data',
+    (
+        pytest.param(
+            {
+                'class': Techniques.CyclicVoltammetry,
+                'potentials': ['vertex1', 'vertex2', 'begin'],
+                'mode': 7,
+            },
+            id='cv',
+        ),
+        pytest.param(
+            {'class': Techniques.ImpedimetricMethod, 'potentials': ['potential'], 'mode': 1},
+            id='eis',
+        ),
+        pytest.param(
+            {'class': Techniques.AmperometricDetection, 'potentials': ['potential'], 'mode': 1},
+            id='ad',
+        ),
+        pytest.param(
+            {'class': Techniques.LinearSweep, 'potentials': ['begin', 'end'], 'mode': 3},
+            id='lsv',
+        ),
+    ),
+)
+def test_VersusOcpSettings(data):
+    obj = data['class']()
 
     params = ps.settings.VersusOCP(
-        mode=7,
-        max_ocp_time=200.0,
+        potentials=data['potentials'],
+        timeout=200.0,
         stability_criterion=123,
     )
     params._export(obj)
 
-    assert obj.OCPmode == 7
+    assert obj.OCPmode == data['mode']
     assert obj.OCPMaxOCPTime == 200
     assert obj.OCPStabilityCriterion == 123
 


### PR DESCRIPTION
This changes how to define versus OCP settings. Previously, the OCP setting was defined using a bitmask via the `mode` parameter. The documentation only noted the modes for CV type experiments. The documentation was incomplete and inaccurate for other types of techniques that support OCP, like EIS, AD, and LSV.

This change documents all the methods that support OCP in the docstring, including which potentials can be defined against OCP. The syntax itself now uses keywords instead of a bitmask to define the OCP potentials.

For example, CV with vertex 1 and 2 defined against OCP:

```pycon
>>> import pypalmsens as ps
>>> method = ps.CyclicVoltammetry(
...	    versus_ocp={
...		    'potentials': ['vertex1', 'vertex2'], 
...		    'timeout': 10,  # s
...	        }
...    )
>>> ps.measure(method, callback=print)
```

So instead of:

```python
VersusOCP(mode=3, max_ocp_time=10)
```

use:

```python
VersusOCP(potentials=['vertex1', 'vertex2'], timeout=10)
```

Closes #331

### TODO

- [x] Figure out which techniques are supported and what flavour they use
- [x] Test PGScan
- [x] Update docstrings
- [x] Update documentation (maybe not needed)
- [x] Expose OCPFlag to pypalmsens.types