### PR TITLE
Streamline multiplexer API with model literals and shorter names

### DIFF
--- a/python/examples/multiplexer.py
+++ b/python/examples/multiplexer.py
@@ -10,7 +10,7 @@ print(instrument)
 
 with ps.connect(instrument) as manager:
     n_multiplexer_channels = manager.initialize_multiplexer('mux8r2')
-    manager.set_mux8r2_settings()
+    manager.configure_mux8r2()
 
     for channel in range(n_multiplexer_channels):
         manager.set_multiplexer_channel(channel)
@@ -23,10 +23,10 @@ with ps.connect(instrument) as manager:
         multiplexer={
             'mode': 'alternate',  # 'none', 'consecutive', 'alternate'
             'channels': [1, 2],  # 8 channels, 1 and 2 are enabled
-            'connect_sense_to_working_electrode': False,
-            'combine_reference_and_counter_electrodes': False,
-            'use_channel_1_reference_and_counter_electrodes': False,
-            'set_unselected_channel_working_electrode': 0,
+            'connect_se_we': False,
+            'combine_re_ce': False,
+            'common_re_ce': False,
+            'unused_we': 'float',
         },
     )
     measurement = manager.measure(altnernating_multiplexer_method, callback=new_data_callback)
@@ -41,10 +41,10 @@ with ps.connect(instrument) as manager:
         multiplexer={
             'mode': 'consecutive',  # 'none', 'consecutive', 'alternate'
             'channels': [1, 2, 7, 8],  # channels 1, 2, 7 and 8 are enabled
-            'connect_sense_to_working_electrode': False,
-            'combine_reference_and_counter_electrodes': False,
-            'use_channel_1_reference_and_counter_electrodes': False,
-            'set_unselected_channel_working_electrode': 0,
+            'connect_se_we': False,
+            'combine_re_ce': False,
+            'common_re_ce': False,
+            'unused_we': 'float',
         },
     )
 

--- a/python/examples/multiplexer.py
+++ b/python/examples/multiplexer.py
@@ -9,7 +9,7 @@ instrument, *_ = ps.discover()
 print(instrument)
 
 with ps.connect(instrument) as manager:
-    n_multiplexer_channels = manager.initialize_multiplexer(2)
+    n_multiplexer_channels = manager.initialize_multiplexer('mux8r2')
     manager.set_mux8r2_settings()
 
     for channel in range(n_multiplexer_channels):

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -21,6 +21,7 @@ from .._converters import (
 )
 from .._types import (
     AllowedCurrentRanges,
+    AllowedMuxModels,
     AllowedPotentialRanges,
     MethodTypeCompatible,
 )
@@ -432,26 +433,31 @@ class InstrumentManager(CapabilitiesMixin, EventsMixin):
 
         return response
 
-    def initialize_multiplexer(self, mux_model: int) -> int:
+    def initialize_multiplexer(self, model: AllowedMuxModels) -> int:
         """Initialize the multiplexer.
 
         Parameters
         ----------
-        mux_model: int
+        model : Literal['mux8', 'mux16', 'mux8r2']
             The model of the multiplexer.
-            - 0 = 8 channel
-            - 1 = 16 channel
-            - 2 = 32 channel
+
+            - 'mux8': 8 channels
+            - 'mux16': 16 channels
+            - 'mux8r2': 8 to 128 channels
 
         Returns
         -------
         channels : int
             Number of available multiplexes channels
         """
-        with self._lock():
-            model = PalmSens.MuxModel(mux_model)
+        mux_model = {
+            'mux8': PalmSens.MuxModel.MUX8,
+            'mux16': PalmSens.MuxModel.MUX16,
+            'mux8r2': PalmSens.MuxModel.MUX8R2,
+        }[model]
 
-            if model == PalmSens.MuxModel.MUX8R2 and (
+        with self._lock():
+            if mux_model == PalmSens.MuxModel.MUX8R2 and (
                 self._comm.ClientConnection.GetType().Equals(
                     clr.GetClrType(PalmSens.Comm.ClientConnectionPS4)
                 )
@@ -461,7 +467,7 @@ class InstrumentManager(CapabilitiesMixin, EventsMixin):
             ):
                 self._comm.ClientConnection.ReadMuxInfo()
 
-            self._comm.Capabilities.MuxModel = model
+            self._comm.Capabilities.MuxModel = mux_model
 
             if self._comm.Capabilities.MuxModel == PalmSens.MuxModel.MUX8:
                 self._comm.Capabilities.NumMuxChannels = 8

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -6,6 +6,7 @@ import warnings
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Literal
 
 import clr
 import PalmSens
@@ -479,25 +480,31 @@ class InstrumentManager(CapabilitiesMixin, EventsMixin):
         channels = self._comm.Capabilities.NumMuxChannels
         return channels
 
-    def set_mux8r2_settings(
+    def configure_mux8r2(
         self,
-        connect_sense_to_working_electrode: bool = False,
-        combine_reference_and_counter_electrodes: bool = False,
-        use_channel_1_reference_and_counter_electrodes: bool = False,
-        set_unselected_channel_working_electrode: int = 0,
+        *,
+        connect_se_we: bool = False,
+        combine_re_ce: bool = False,
+        common_re_ce: bool = False,
+        unused_we: Literal['float', 'ground', 'standby'] = 'float',
     ):
-        """Set the settings for the Mux8R2 multiplexer.
+        """Configure the Mux8R2 multiplexer.
+
+        This method sets the Mux8R2 parameters globally, including for techniques.
+        If you specify [pypalmsens.settings.Multiplexer][] in your technique,
+        those settings will override the values set here.
 
         Parameters
         ---------
-        connect_sense_to_working_electrode: float
+        connect_se_we : bool, optional
             Connect the sense electrode to the working electrode. Default is False.
-        combine_reference_and_counter_electrodes: float
+        combine_re_ce : bool, optional
             Combine the reference and counter electrodes. Default is False.
-        use_channel_1_reference_and_counter_electrodes: float
+        common_re_ce : bool, optional
             Use channel 1 reference and counter electrodes for all working electrodes. Default is False.
-        set_unselected_channel_working_electrode: float
-            Set the unselected channel working electrode to disconnected/floating (0), ground (1), or standby potential (2). Default is 0.
+        unused_we : Literal['float', 'ground', 'standby'], optional
+            State of the unused channel working electrodes: floating,
+            ground, or standby potential. Default is 'float'.
         """
         self.ensure_connection()
 
@@ -507,12 +514,15 @@ class InstrumentManager(CapabilitiesMixin, EventsMixin):
             )
 
         mux_settings = PalmSens.Method.MuxSettings(False)
-        mux_settings.ConnSEWE = connect_sense_to_working_electrode
-        mux_settings.ConnectCERE = combine_reference_and_counter_electrodes
-        mux_settings.CommonCERE = use_channel_1_reference_and_counter_electrodes
-        mux_settings.UnselWE = PalmSens.Method.MuxSettings.UnselWESetting(
-            set_unselected_channel_working_electrode
-        )
+        mux_settings.ConnSEWE = connect_se_we
+        mux_settings.ConnectCERE = combine_re_ce
+        mux_settings.CommonCERE = common_re_ce
+        unused_we_setting = {
+            'float': PalmSens.Method.MuxSettings.UnselWESetting.FLOAT,
+            'ground': PalmSens.Method.MuxSettings.UnselWESetting.GND,
+            'standby': PalmSens.Method.MuxSettings.UnselWESetting.VSTDBY,
+        }[unused_we]
+        mux_settings.UnselWE = unused_we_setting
 
         with self._lock():
             self._comm.ClientConnection.SetMuxSettings(MuxType(1), mux_settings)

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -7,7 +7,7 @@ import warnings
 from collections.abc import AsyncGenerator, Coroutine
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import clr
 import PalmSens
@@ -535,25 +535,31 @@ class InstrumentManagerAsync(CapabilitiesMixin, EventsMixin):
         channels = self._comm.Capabilities.NumMuxChannels
         return channels
 
-    async def set_mux8r2_settings(
+    async def configure_mux8r2(
         self,
-        connect_sense_to_working_electrode: bool = False,
-        combine_reference_and_counter_electrodes: bool = False,
-        use_channel_1_reference_and_counter_electrodes: bool = False,
-        set_unselected_channel_working_electrode: int = 0,
+        *,
+        connect_se_we: bool = False,
+        combine_re_ce: bool = False,
+        common_re_ce: bool = False,
+        unused_we: Literal['float', 'ground', 'standby'] = 'float',
     ):
-        """Set the settings for the Mux8R2 multiplexer.
+        """Configure the Mux8R2 multiplexer.
+
+        This method sets the Mux8R2 parameters globally, including for techniques.
+        If you specify [pypalmsens.settings.Multiplexer][] in your technique,
+        those settings will override the values set here.
 
         Parameters
         ---------
-        connect_sense_to_working_electrode: float
+        connect_se_we : bool, optional
             Connect the sense electrode to the working electrode. Default is False.
-        combine_reference_and_counter_electrodes: float
+        combine_re_ce : bool, optional
             Combine the reference and counter electrodes. Default is False.
-        use_channel_1_reference_and_counter_electrodes: float
+        common_re_ce : bool, optional
             Use channel 1 reference and counter electrodes for all working electrodes. Default is False.
-        set_unselected_channel_working_electrode: float
-            Set the unselected channel working electrode to disconnected/floating (0), ground (1), or standby potential (2). Default is 0.
+        unused_we : Literal['float', 'ground', 'standby'], optional
+            State of the unused channel working electrodes: floating,
+            ground, or standby potential. Default is 'float'.
         """
         self.ensure_connection()
 
@@ -563,12 +569,15 @@ class InstrumentManagerAsync(CapabilitiesMixin, EventsMixin):
             )
 
         mux_settings = PalmSens.Method.MuxSettings(False)
-        mux_settings.ConnSEWE = connect_sense_to_working_electrode
-        mux_settings.ConnectCERE = combine_reference_and_counter_electrodes
-        mux_settings.CommonCERE = use_channel_1_reference_and_counter_electrodes
-        mux_settings.UnselWE = PalmSens.Method.MuxSettings.UnselWESetting(
-            set_unselected_channel_working_electrode
-        )
+        mux_settings.ConnSEWE = connect_se_we
+        mux_settings.ConnectCERE = combine_re_ce
+        mux_settings.CommonCERE = common_re_ce
+        unused_we_setting = {
+            'float': PalmSens.Method.MuxSettings.UnselWESetting.FLOAT,
+            'ground': PalmSens.Method.MuxSettings.UnselWESetting.GND,
+            'standby': PalmSens.Method.MuxSettings.UnselWESetting.VSTDBY,
+        }[unused_we]
+        mux_settings.UnselWE = unused_we_setting
 
         async with self._lock():
             await create_future(

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -23,6 +23,7 @@ from .._converters import (
 )
 from .._types import (
     AllowedCurrentRanges,
+    AllowedMuxModels,
     AllowedPotentialRanges,
     MethodTypeCompatible,
 )
@@ -488,26 +489,31 @@ class InstrumentManagerAsync(CapabilitiesMixin, EventsMixin):
 
         return response
 
-    async def initialize_multiplexer(self, mux_model: int) -> int:
+    async def initialize_multiplexer(self, model: AllowedMuxModels) -> int:
         """Initialize the multiplexer.
 
         Parameters
         ----------
-        mux_model: int
+        model : Literal['mux8', 'mux16', 'mux8r2']
             The model of the multiplexer.
-            - 0 = 8 channel
-            - 1 = 16 channel
-            - 2 = 32 channel
+
+            - 'mux8': 8 channels
+            - 'mux16': 16 channels
+            - 'mux8r2': 8 to 128 channels
 
         Returns
         -------
         channels : int
             Number of available multiplexes channels
         """
-        async with self._lock():
-            model = PalmSens.MuxModel(mux_model)
+        mux_model = {
+            'mux8': PalmSens.MuxModel.MUX8,
+            'mux16': PalmSens.MuxModel.MUX16,
+            'mux8r2': PalmSens.MuxModel.MUX8R2,
+        }[model]
 
-            if model == PalmSens.MuxModel.MUX8R2 and (
+        async with self._lock():
+            if mux_model == PalmSens.MuxModel.MUX8R2 and (
                 self._comm.ClientConnection.GetType().Equals(
                     clr.GetClrType(PalmSens.Comm.ClientConnectionPS4)
                 )
@@ -517,7 +523,7 @@ class InstrumentManagerAsync(CapabilitiesMixin, EventsMixin):
             ):
                 await create_future(self._comm.ClientConnection.ReadMuxInfoAsync())
 
-            self._comm.Capabilities.MuxModel = model
+            self._comm.Capabilities.MuxModel = mux_model
 
             if self._comm.Capabilities.MuxModel == PalmSens.MuxModel.MUX8:
                 self._comm.Capabilities.NumMuxChannels = 8

--- a/python/src/pypalmsens/_methods/settings.py
+++ b/python/src/pypalmsens/_methods/settings.py
@@ -608,6 +608,12 @@ class Multiplexer(BaseSettings):
         'alternate',
     )
 
+    _UNUSED_WE_STATES: tuple[Literal['float', 'ground', 'standby'], ...] = (
+        'float',
+        'ground',
+        'standby',
+    )
+
     mode: Literal['none', 'consecutive', 'alternate'] = 'none'
     """Set multiplexer mode.
 
@@ -627,17 +633,23 @@ class Multiplexer(BaseSettings):
     In alternating mode the first channel must be selected and all other
     channels should be consecutive i.e. (channel 1, channel 2, channel 3 and so on).
     """
-    connect_sense_to_working_electrode: bool = False
+    connect_se_we: bool = False
     """Connect the sense electrode to the working electrode. Default is False."""
 
-    combine_reference_and_counter_electrodes: bool = False
+    combine_re_ce: bool = False
     """Combine the reference and counter electrodes. Default is False."""
 
-    use_channel_1_reference_and_counter_electrodes: bool = False
+    common_re_ce: bool = False
     """Use channel 1 reference and counter electrodes for all working electrodes. Default is False."""
 
-    set_unselected_channel_working_electrode: int = 0
-    """Set the unselected channel working electrode to 0 = Disconnected / floating, 1 = Ground, 2 = Standby potential. Default is 0."""
+    unused_we: Literal['float', 'ground', 'standby'] = 'float'
+    """State of the unused channel working electrodes:
+
+    - `float`: Disconnected / floating
+    - `ground`: Ground
+    - `standby`: Standby potential
+
+    Default is `'float'`."""
 
     @override
     def _export(self, psmethod: PalmSens.Method, /):
@@ -653,12 +665,15 @@ class Multiplexer(BaseSettings):
         for i in self.channels:
             psmethod.UseMuxChannel[i - 1] = True
 
-        psmethod.MuxSett.ConnSEWE = self.connect_sense_to_working_electrode
-        psmethod.MuxSett.ConnectCERE = self.combine_reference_and_counter_electrodes
-        psmethod.MuxSett.CommonCERE = self.use_channel_1_reference_and_counter_electrodes
-        psmethod.MuxSett.UnselWE = PalmSens.Method.MuxSettings.UnselWESetting(
-            self.set_unselected_channel_working_electrode
-        )
+        psmethod.MuxSett.ConnSEWE = self.connect_se_we
+        psmethod.MuxSett.ConnectCERE = self.combine_re_ce
+        psmethod.MuxSett.CommonCERE = self.common_re_ce
+        unused_we_setting = {
+            'float': PalmSens.Method.MuxSettings.UnselWESetting.FLOAT,
+            'ground': PalmSens.Method.MuxSettings.UnselWESetting.GND,
+            'standby': PalmSens.Method.MuxSettings.UnselWESetting.VSTDBY,
+        }[self.unused_we]
+        psmethod.MuxSett.UnselWE = unused_we_setting
 
     @override
     def _import(self, psmethod: PalmSens.Method, /):
@@ -668,10 +683,10 @@ class Multiplexer(BaseSettings):
             i + 1 for i in range(len(psmethod.UseMuxChannel)) if psmethod.UseMuxChannel[i]
         ]
 
-        self.connect_sense_to_working_electrode = psmethod.MuxSett.ConnSEWE
-        self.combine_reference_and_counter_electrodes = psmethod.MuxSett.ConnectCERE
-        self.use_channel_1_reference_and_counter_electrodes = psmethod.MuxSett.CommonCERE
-        self.set_unselected_channel_working_electrode = int(psmethod.MuxSett.UnselWE)
+        self.connect_se_we = psmethod.MuxSett.ConnSEWE
+        self.combine_re_ce = psmethod.MuxSett.ConnectCERE
+        self.common_re_ce = psmethod.MuxSett.CommonCERE
+        self.unused_we = self._UNUSED_WE_STATES[int(psmethod.MuxSett.UnselWE)]
 
 
 class DataProcessing(BaseSettings):

--- a/python/src/pypalmsens/_types.py
+++ b/python/src/pypalmsens/_types.py
@@ -131,6 +131,15 @@ See the device documentation or query the instrument manager
 for supported potential ranges."""
 
 
+AllowedMuxModels = Literal['mux8', 'mux16', 'mux8r2']
+"""Possible multiplexer models.
+
+- 'mux8': 8 channels
+- 'mux16': 16 channels
+- 'mux8r2': 8 to 128 channels
+"""
+
+
 AllowedScanTypes = Literal['potential', 'current', 'time', 'fixed']
 """Possible scan types."""
 

--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -375,10 +375,10 @@ def test_MultiplexerSettings():
     params = ps.settings.Multiplexer(
         mode='consecutive',
         channels=[1, 3, 5],
-        connect_sense_to_working_electrode=True,
-        combine_reference_and_counter_electrodes=True,
-        use_channel_1_reference_and_counter_electrodes=True,
-        set_unselected_channel_working_electrode=1,
+        connect_se_we=True,
+        combine_re_ce=True,
+        common_re_ce=True,
+        unused_we='ground',
     )
     params._export(obj)
 


### PR DESCRIPTION
This PR cleans up the multiplexer / mux initializers. These had a few issues.

1. Relying on ints to configure the model (error-prone)
2. Wrong documentations (mux8r2)
3. Long parameters names

Closes #466 

## Multiplexer API changes (breaking)

### `initialize_multiplexer` now takes a model name instead of an int

```python
# before
manager.initialize_multiplexer(2)

# after
manager.initialize_multiplexer('mux8r2')
```

Valid values are `'mux8'`, `'mux16'` and `'mux8r2'`.

### `set_mux8r2_settings` renamed to `configure_mux8r2` with shorter parameter names

```python
# before
manager.set_mux8r2_settings(
    connect_sense_to_working_electrode=True,
    combine_reference_and_counter_electrodes=False,
    use_channel_1_reference_and_counter_electrodes=False,
    set_unselected_channel_working_electrode=0,
)

# after
manager.configure_mux8r2(
    connect_se_we=True,
    combine_re_ce=False,
    common_re_ce=False,
    unused_we='float',
)
```

Parameters are now keyword-only. `unused_we` takes a string instead of an integer (`0/1/2` → `'float'/'ground'/'standby'`).

### `settings.Multiplexer` field renames

The same renames apply to the per-technique multiplexer settings:

| 1.x | 2.0 |
|---|---|
| `connect_sense_to_working_electrode` | `connect_se_we` |
| `combine_reference_and_counter_electrodes` | `combine_re_ce` |
| `use_channel_1_reference_and_counter_electrodes` | `common_re_ce` |
| `set_unselected_channel_working_electrode` (int) | `unused_we` (`'float'`, `'ground'`, `'standby'`) |

```python
# before
ps.ChronoAmperometry(
    ...,
    multiplexer={
        'mode': 'alternate',
        'channels': [1, 2],
        'connect_sense_to_working_electrode': False,
        'combine_reference_and_counter_electrodes': False,
        'use_channel_1_reference_and_counter_electrodes': False,
        'set_unselected_channel_working_electrode': 0,
    },
)

# after
ps.ChronoAmperometry(
    ...,
    multiplexer={
        'mode': 'alternate',
        'channels': [1, 2],
        'connect_se_we': False,
        'combine_re_ce': False,
        'common_re_ce': False,
        'unused_we': 'float',
    },
)
```
