### PR TITLE
Implement read/write digital pins

### DIFF
--- a/python/docs/zensical/gpio.md
+++ b/python/docs/zensical/gpio.md
@@ -1,0 +1,118 @@
+# Digital I/O (GPIO)
+
+The [pypalmsens.Gpio] and [pypalmsens.GpioAsync] classes provide access to the instrument’s digital input and output pins. Use it to read logic levels, drive outputs, or toggle control lines. The gpio api is exposed via the [InstrumentManager.gpio][pypalmsens.InstrumentManager.gpio] and [InstrumentManagerAsync.gpio][pypalmsens.InstrumentManagerAsync.gpio] attributes.
+
+- **Direction auto-configuration:** For MethodSCRIPT devices, the library automatically configures pin direction when you call [read][pypalmsens.Gpio.read] (input) or [write][pypalmsens.Gpio.write] / [toggle][pypalmsens.Gpio.toggle] (output) operations. If you need explicit low-level control, use [MethodSCRIPT](https://dev.palmsens.com/methodscript/latest/methodscript/methodscript_main.html), either directly or via [pypalmsens.CommProtocol][].
+
+- **Atomicity:** [write_many][pypalmsens.Gpio.write_many] and [toggle_many][pypalmsens.Gpio.toggle_many] are sent as a single instruction. How the chip process the instruction may differ from device to device. If your use case requires strict timing (e.g., simultaneous pin changes), prefer the batch methods over multiple single-pin calls.
+
+## Pin numbering
+
+The integers you pass to read / write are the internal pin numbers exposed by the firmware API, not necessarily the labels on the hardware (e.g., d0, d3). The mapping is consistent for a given instrument model, so code that works on one unit will work on an identical unit. Consult the instrument manual for the physical mapping.
+
+Pin numbers and the mix of readable vs. writable pins depend on the specific instrument model. Consult [writable_pins][pypalmsens.Gpio.writable_pins] and [readable_pins][pypalmsens.Gpio.readable_pins] at runtime if you work with multiple device types.
+
+## Available pins
+
+Before reading or writing, check which pins are configured for input and output on the connected instrument, for example a PalmSens 4:
+
+```pycon
+>>> import pypalmsens as ps
+
+>>> with ps.connect() as manager:
+...     print("Outputs:", manager.gpio.writable_pins)
+...     print("Inputs :", manager.gpio.readable_pins)
+Outputs: [0, 1, 2, 3]
+Inputs : [0]
+
+```
+
+## Writing digital outputs
+
+Set a single pin high or low:
+
+```pycon
+>>> with ps.connect() as manager:
+...     manager.gpio.write(1, level='high')
+...     manager.gpio.write(2, level='low')
+
+```
+
+Set multiple pins at once:
+
+```pycon
+>>> with ps.connect() as manager:
+...    # Set pins 1, 2 and 3 high in one call
+...    manager.gpio.write_many([1, 2, 3], level='high')
+
+```
+
+## Reading digital inputs
+
+Read the current level of a single pin or several pins:
+
+```pycon
+>>> with ps.connect() as manager:
+...    level = manager.gpio.read(0)
+...    print(f"Pin 0 is {level!r}")
+...
+...    levels = manager.gpio.read_many([0, 1])
+...    print(levels)
+Pin 0 is 'low'
+['low', 'high']
+```
+
+## Toggling outputs
+
+Invert the current state of an output pin without knowing its present level:
+
+```pycon
+>>> with ps.connect() as manager:
+...     manager.gpio.toggle(1)               # single pin
+...     manager.gpio.toggle_many([1, 2, 3])  # multiple pins
+
+```
+
+## Complete example
+
+```python
+import pypalmsens as ps
+
+instrument, *_ = ps.discover()
+
+with ps.InstrumentManager(instrument) as manager:
+    # Initialise control pins
+    manager.gpio.write_many([1, 2], level='low')
+
+    # Enable external circuitry on pin 1
+    manager.gpio.write(1, level='high')
+
+    # Check status on pin 0
+    if manager.gpio.read(0) == 'high':
+        manager.gpio.toggle(2)
+
+    # Bulk reset all pins
+    output_pins = manager.gpio.writable_pins
+    manager.gpio.write_many(output_pins, level='low')
+
+```
+
+
+## Async usage
+
+For async workflows, use `AsyncInstrumentManager.gpio`. All these methods are `await`-able and behave identically to their synchronous counterparts.
+
+```python
+import asyncio
+import pypalmsens as ps
+
+async def main():
+    instrument, *_ = await ps.discover_async()
+
+    async with ps.InstrumentManagerAsync(instrument) as manager:
+        await manager.gpio.write_async(1, level='high')
+        state = await manager.gpio.read_async(0)
+        print(f"Pin 0 is {state}")
+
+asyncio.run(main())
+```

--- a/python/docs/zensical/reference/gpio.md
+++ b/python/docs/zensical/reference/gpio.md
@@ -1,0 +1,30 @@
+# GPIO
+
+This class provides high-level access to the instrument's digital pins.
+The API is defined in [pypalmsens.Gpio][], and [pypalmsens.GpioAsync][] for asynchronous workflows.
+
+The intended usage of these classes is via the [InstrumentManager.gpio][pypalmsens.InstrumentManager.gpio] and [InstrumentManager.gpio][pypalmsens.InstrumentManager.gpio] attributes.
+
+Example:
+
+```pycon
+>>> import pypalmsens as ps
+
+>>> with ps.connect() as manager:
+...     print("Outputs:", manager.gpio.writable_pins)
+...     print("Inputs :", manager.gpio.readable_pins)
+...     manager.gpio.write_many([0,1,2], level='high')
+Outputs: [0, 1, 2, 3]
+Inputs : [0]
+
+```
+
+For more information how to use these classes, see [the documentation here](../gpio.md).
+
+**Classes:**
+
+- [`pypalmsens.Gpio`][pypalmsens.Gpio]
+- [`pypalmsens.GpioAsync`][pypalmsens.GpioAsync]
+
+::: pypalmsens.Gpio
+::: pypalmsens.GpioAsync

--- a/python/src/pypalmsens/__init__.py
+++ b/python/src/pypalmsens/__init__.py
@@ -30,6 +30,8 @@ from ._instruments.comm_protocol import CommProtocol
 from ._instruments.comm_protocol_async import CommProtocolAsync
 from ._instruments.filesystem import DeviceFileSystem, DevicePath
 from ._instruments.filesystem_async import DeviceFileSystemAsync
+from ._instruments.gpio import Gpio
+from ._instruments.gpio_async import GpioAsync
 from ._instruments.instrument import Instrument, discover, discover_async
 from ._instruments.instrument_manager import (
     InstrumentManager,
@@ -97,6 +99,8 @@ __all__ = [
     'FastGalvanostaticImpedanceSpectroscopy',
     'FastImpedanceSpectroscopy',
     'GalvanostaticImpedanceSpectroscopy',
+    'Gpio',
+    'GpioAsync',
     'Instrument',
     'InstrumentManager',
     'InstrumentManagerAsync',

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -41,10 +41,15 @@ class GPIO:
         ValueError:
             If the requested output pin is not supported by the device.
         """
-        if pin < 0:
+        [out] = self.read_pins([pin])
+        return out
+
+    def read_pins(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
+        """Read pins configured as input."""
+        if min(pins) < 0:
             raise ValueError('Pin cannot be negative.')
 
-        mask = 1 << pin
+        mask = self._pins_to_bitmask(pins)
 
         is_methodscript = isinstance(
             self.manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
@@ -58,19 +63,21 @@ class GPIO:
             if not (mask & supported_mask):
                 raise ValueError('Requested input pin is not supported by device.')
         else:
-            if pin > 1:
+            if max(pins):
                 raise ValueError('Requested input pin is not supported by device.')
 
         with self.manager._lock():
-            level = self.manager._comm.ClientConnection.ReadDigitalLine(mask)
+            # TODO: fix bug, this returns either returns all True or all False
+            level_mask = self.manager._comm.ClientConnection.ReadDigitalLine(mask)
 
-        return ('low', 'high')[level]
+        levels = []
+        for pin in pins:
+            pin_mask = 1 << pin
+            levels.append(pin_mask & level_mask == pin_mask)
 
-    def read_pins(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
-        """Read pins configured as input."""
-        mask = self._pins_to_bitmask(pins)
+        print(f'{level_mask=}, {mask=}, {levels=}')
 
-        return []
+        return levels
 
     def _write_pins(self, pins: Sequence[int], func: Callable[[int, int], int]):
         if min(pins) < 0:
@@ -154,3 +161,6 @@ class GPIO:
     def _bitmask_to_pins(mask: int) -> list[int]:
         """Convert a bitmask (integer) into a list pin indices."""
         return [i for i in range(8) if (mask & (1 << i))]
+
+    def supported_pins(self):
+        pass

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Literal, final
+
+import PalmSens
+
+if TYPE_CHECKING:
+    from .instrument_manager import InstrumentManager
+
+
+@final
+class GPIO:
+    """High level gpio interface.
+
+    For more fine-grained control, use MethodSCRIPT (if your device supports it):
+
+        - [pypalmsens.CommProtocol][]
+        - [MethodSCRIPT manual](https://dev.palmsens.com/methodscript/latest/methodscript/methodscript_main.html)
+
+
+    """
+
+    def __init__(self, manager: InstrumentManager):
+        self.manager = manager
+
+    def read_pin(self, pin: int) -> Literal['low', 'high']:
+        """Reads the state of a GPIO pin.
+
+        The pin configuration is automatically switched to input if needed.
+
+        Check your device documentation for the available input pins.
+
+        Parameters
+        ----------
+        pin: integer
+            The integer index of the GPIO pin to read.
+
+        Raises
+        ------
+        ValueError:
+            If the requested output pin is not supported by the device.
+        """
+        if pin < 0:
+            raise ValueError('Pin cannot be negative.')
+
+        mask = 1 << pin
+
+        is_methodscript = isinstance(
+            self.manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
+        )
+
+        if is_methodscript:
+            supported_mask = (
+                self.manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask
+            )
+
+            if not (mask & supported_mask):
+                raise ValueError('Requested input pin is not supported by device.')
+        else:
+            if pin > 1:
+                raise ValueError('Requested input pin is not supported by device.')
+
+        with self.manager._lock():
+            level = self.manager._comm.ClientConnection.ReadDigitalLine(mask)
+
+        return ('low', 'high')[level]
+
+    def read_pins(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
+        """Read pins configured as input."""
+        mask = self._pins_to_bitmask(pins)
+
+        return []
+
+    def _write_pins(self, pins: Sequence[int], func: Callable[[int, int], int]):
+        if min(pins) < 0:
+            raise ValueError('Pin cannot be negative.')
+
+        mask = self._pins_to_bitmask(pins)
+
+        is_methodscript = isinstance(
+            self.manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
+        )
+
+        with self.manager._lock():
+            if is_methodscript:
+                supported_mask = self.manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask
+
+                if not (mask & supported_mask):
+                    raise ValueError('Requested output pin is not supported by device.')
+
+                current = self.manager._comm.ClientConnection.ReadDigitalLine(supported_mask)
+            else:
+                if max(pins) > 3:
+                    raise ValueError('Requested output pin is not supported by device.')
+
+                current = self.manager._comm.DigitalOutput
+
+            mask = func(mask, current)
+
+            self.manager._comm.ClientConnection.SetDigitalOutput(mask)
+
+    def write_pins(self, pins: Sequence[int], level: Literal['low', 'high'] = 'high'):
+        if level == 'high':
+            func = lambda current, mask: current | mask  # high
+        elif level == 'low':
+            func = lambda current, mask: current & ~mask  # low
+        else:
+            raise ValueError("`level` must be one of 'low', 'high', 'toggle'")
+
+        return self._write_pins(pins, func)
+
+    def write_pin(self, pin: int, level: Literal['low', 'high'] = 'high'):
+        """Writes a specified state to a GPIO pin.
+
+        The pin configuration is automatically switched to output if needed.
+
+        Check your device documentation for available output pins.
+
+        Parameters
+        ----------
+        pin: integer
+            The integer index of the GPIO pin to control.
+        level: Literal['low', 'high', 'toggle']
+            The desired output level. Must be one of 'low', 'high', or 'toggle'.
+            Defaults to 'high'.
+
+        Raises
+        ------
+        ValueError:
+            If the requested output pin is not supported by the device,
+            or if an invalid value is provided for `level`.
+        """
+        self.write_pins([pin], level=level)
+
+    def toggle_pin(self, pin: int):
+        return self.toggle_pins([pin])
+
+    def toggle_pins(self, pins: Sequence[int]):
+        func = lambda mask, current: current ^ mask  # toggle
+
+        return self._write_pins(pins, func)
+
+    @staticmethod
+    def _pins_to_bitmask(pins: Sequence[int]) -> int:
+        """Convert a list of pin indices into a bitmask (integer)."""
+        mask = 0
+        for pin in pins:
+            mask |= 1 << pin
+
+        return mask
+
+    @staticmethod
+    def _bitmask_to_pins(mask: int) -> list[int]:
+        """Convert a bitmask (integer) into a list pin indices."""
+        return [i for i in range(8) if (mask & (1 << i))]

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -9,27 +9,43 @@ if TYPE_CHECKING:
     from .instrument_manager import InstrumentManager
 
 
+class GPIOError(ValueError): ...
+
+
+class PinNotSupportedError(GPIOError): ...
+
+
 @final
 class GPIO:
-    """High level gpio interface.
+    """Digital general-purpose input/output (GPIO) interface.
 
-    For more fine-grained control, use MethodSCRIPT (if your device supports it):
+    This class provides high-level access to the instrument's digital
+    pins. Pin numbering is hardware-specific. Consult the instrument
+    manual for the physical mapping.
+
+    Note that the pins are typically referred to as `d0` or `d3`.
+    These correspond to pins 0 and 3 in this interface, respectively.
+
+    For MethodSCRIPT devices, the underlying libraries auto-configures
+    read/write direction on read/write instructions.
+
+    For explicit control, use the low-level MethodSCRIPT primitives directly:
 
         - [pypalmsens.CommProtocol][]
         - [MethodSCRIPT manual](https://dev.palmsens.com/methodscript/latest/methodscript/methodscript_main.html)
-
-
     """
 
     def __init__(self, manager: InstrumentManager):
-        self.manager = manager
+        self._manager = manager
 
     @property
     def _is_methodscript(self) -> bool:
-        return isinstance(self.manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS)
+        return isinstance(
+            self._manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
+        )
 
     def read_pin(self, pin: int) -> Literal['low', 'high']:
-        """Reads the state of a GPIO pin.
+        """Read the logic level of a single digital input pin.
 
         The pin configuration is automatically switched to input if needed.
 
@@ -38,25 +54,48 @@ class GPIO:
         Parameters
         ----------
         pin: integer
-            The integer index of the GPIO pin to read.
+            Pin number to read.
+
+        Returns
+        -------
+        level : {'low', 'high'}
+            Current logic level of the requested pin.
 
         Raises
         ------
-        ValueError:
-            If the requested output pin is not supported by the device.
+        PinNotSupportedError:
+            If ``pin`` is not a supported input pin.
         """
-        [out] = self.read_pins([pin])
-        return out
+        [level] = self.read_pins([pin])
+        return level
 
     def read_pins(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
-        """Read pins configured as input."""
+        """Read the logic levels of multiple digital input pins.
+
+        Parameters
+        ----------
+        pins : Sequence[int]
+            Pin numbers to read. The order is preserved in the
+            returned values.
+
+        Returns
+        -------
+        levels : list of {'low', 'high'}
+            Logic levels corresponding to the requested ``pins``,
+            in the same order.
+
+        Raises
+        ------
+        PinNotSupportedError
+            If any pin in ``pins`` is not a supported input pin.
+        """
         self._raise_if_pins_not_supported(pins, 'read')
 
         mask = self._pins_to_bitmask(pins)
 
-        with self.manager._lock():
+        with self._manager._lock():
             # TODO: fix bug, this returns either returns all True or all False
-            level_mask = self.manager._comm.ClientConnection.ReadDigitalLine(mask)
+            level_mask = self._manager._comm.ClientConnection.ReadDigitalLine(mask)
 
         levels = []
         for pin in pins:
@@ -72,51 +111,99 @@ class GPIO:
 
         mask = self._pins_to_bitmask(pins)
 
-        current = self.manager._comm.DigitalOutput
+        current = self._manager._comm.DigitalOutput
 
         mask = func(mask, current)
 
-        with self.manager._lock():
-            self.manager._comm.ClientConnection.SetDigitalOutput(mask)
+        with self._manager._lock():
+            self._manager._comm.ClientConnection.SetDigitalOutput(mask)
 
     def write_pins(self, pins: Sequence[int], level: Literal['low', 'high'] = 'high'):
+        """Set the logic level of multiple digital output pins.
+
+        Parameters
+        ----------
+        pins : Sequence[int]
+            Pin numbers to write.
+        level : {'low', 'high'}, optional
+            Logic level to set on all specified pins.  Default is
+            ``'high'``.
+
+        Raises
+        ------
+        PinNotSupportedError
+            If any pin in ``pins`` is not a supported output pin.
+        """
         if level == 'high':
-            func = lambda current, mask: current | mask  # high
+
+            def func(current: int, mask: int) -> int:
+                return current | mask  # high
         elif level == 'low':
-            func = lambda current, mask: current & ~mask  # low
+
+            def func(current: int, mask: int) -> int:
+                return current & ~mask  # low
         else:
-            raise ValueError("`level` must be one of 'low', 'high', 'toggle'")
+            raise ValueError("`level` must be one of 'low' or 'high'")
 
         return self._write_pins(pins, func)
 
     def write_pin(self, pin: int, level: Literal['low', 'high'] = 'high'):
-        """Writes a specified state to a GPIO pin.
-
-        The pin configuration is automatically switched to output if needed.
-
-        Check your device documentation for available output pins.
+        """Set the logic level of a single digital output pin.
 
         Parameters
         ----------
-        pin: integer
-            The integer index of the GPIO pin to control.
-        level: Literal['low', 'high', 'toggle']
-            The desired output level. Must be one of 'low', 'high', or 'toggle'.
-            Defaults to 'high'.
+        pin : int
+            Pin number to write.
+        level : {'low', 'high'}, optional
+            Logic level to set.  Default is ``'high'``.
 
         Raises
         ------
-        ValueError:
-            If the requested output pin is not supported by the device,
-            or if an invalid value is provided for `level`.
+        PinNotSupportedError:
+            If ``pin`` is not a supported input pin.
         """
         self.write_pins([pin], level=level)
 
     def toggle_pin(self, pin: int):
+        """Invert the logic level of a single digital output pin.
+
+        A ``high`` state becomes ``low`` and vice-versa.
+
+        Parameters
+        ----------
+        pin : int
+            Pin number to toggle.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        PinNotSupportedError
+            If ``pin`` is not a supported output pin.
+        """
         return self.toggle_pins([pin])
 
     def toggle_pins(self, pins: Sequence[int]):
-        func = lambda mask, current: current ^ mask  # toggle
+        """Invert the logic level of multiple digital output pins.
+
+        Each pin is toggled independently: ``high`` becomes ``low``
+        and ``low`` becomes ``high``.
+
+        Parameters
+        ----------
+        pins : Sequence[int]
+            Pin numbers to toggle.
+
+        Raises
+        ------
+        PinNotSupportedError
+            If any pin in ``pins`` is not a supported output pin.
+        """
+
+        def func(current: int, mask: int) -> int:
+            return current ^ mask  # toggle
 
         return self._write_pins(pins, func)
 
@@ -134,23 +221,46 @@ class GPIO:
         """Convert a bitmask (integer) into a list pin indices."""
         return [i for i in range(8) if (mask & (1 << i))]
 
-    def supported_write_pins(self) -> list[int]:
-        mask = self.manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask
+    @property
+    def writable_pins(self) -> list[int]:
+        """Return the pin numbers that support digital output.
+
+        Returns
+        -------
+        list[int]
+            Sorted list of pin numbers that can be used with
+            `write_pin`, `write_pins`, `toggle_pin`,
+            and `toggle_pins`.
+        """
+        if not self._is_methodscript:
+            raise GPIOError('Only supported on MethodSCRIPT devices.')
+        mask = self._manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask
         return self._bitmask_to_pins(mask)
 
-    def supported_read_pins(self) -> list[int]:
-        mask = self.manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask
+    @property
+    def readable_pins(self) -> list[int]:
+        """Return the pin numbers that support digital input.
+
+        Returns
+        -------
+        list[int]
+            Sorted list of pin numbers that can be used with
+            `read_pin` and `read_pins`.
+        """
+        if not self._is_methodscript:
+            raise GPIOError('Only supported on MethodSCRIPT devices.')
+        mask = self._manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask
         return self._bitmask_to_pins(mask)
 
     def _raise_if_pins_not_supported(self, pins: Sequence[int], mode: Literal['read', 'write']):
         if min(pins) < 0:
-            raise ValueError('Pin cannot be negative.')
+            raise PinNotSupportedError('Pin cannot be negative.')
 
         if self._is_methodscript:
             pin_mask = self._pins_to_bitmask(pins)
             supported_mask = {
-                'write': self.manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask,
-                'read': self.manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask,
+                'write': self._manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask,
+                'read': self._manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask,
             }[mode]
 
             if pin_mask & supported_mask:
@@ -159,6 +269,6 @@ class GPIO:
             if max(pins) < 4:
                 return
 
-        raise ValueError(
-            f'Requested {mode} pin is not supported by {self.manager.instrument.name}.'
+        raise PinNotSupportedError(
+            f'Requested {mode} pin is not supported by {self._manager.instrument.name}.'
         )

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -36,15 +36,11 @@ def is_methodscript(client_connection: PalmSens.Comm.ClientConnection) -> bool:
 def writable_pins(client_connection: PalmSens.Comm.ClientConnection) -> list[int]:
     """Return the pin numbers that support digital output.
 
-    Returns
-    -------
-    list[int]
-        Sorted list of pin numbers that can be used with
-        `write`, `write_many`, `toggle`,
-        and `toggle_many`.
+    Return fixed pin numbers for the most common configuration for
+    non-MethodSCRIPT devices.
     """
     if not is_methodscript(client_connection):
-        raise GPIOError('Only supported on MethodSCRIPT devices.')
+        return [0, 1, 2, 3]
     mask = client_connection.Capabilities.SupportedDigitalOutputLineMask
     return bitmask_to_pins(mask)
 
@@ -52,14 +48,11 @@ def writable_pins(client_connection: PalmSens.Comm.ClientConnection) -> list[int
 def readable_pins(client_connection: PalmSens.Comm.ClientConnection) -> list[int]:
     """Return the pin numbers that support digital input.
 
-    Returns
-    -------
-    list[int]
-        Sorted list of pin numbers that can be used with
-        `read` and `read_many`.
+    Return fixed pin numbers for the most common configuration for
+    non-MethodSCRIPT devices.
     """
     if not is_methodscript(client_connection):
-        raise GPIOError('Only supported on MethodSCRIPT devices.')
+        return [0]
     mask = client_connection.Capabilities.SupportedDigitalInputLineMask
     return bitmask_to_pins(mask)
 
@@ -96,8 +89,9 @@ class GPIO:
     pins. Pin numbering is hardware-specific. Consult the instrument
     manual for the physical mapping.
 
-    Note that the pins are typically referred to as `d0` or `d3`.
-    These correspond to pins 0 and 3 in this interface, respectively.
+    Note that the internal numbering of the pins exposed by this class
+    may differ from the documented pins numbering, e.g. `d0` or `d3`.
+    The pin numbering is interally consistent.
 
     For MethodSCRIPT devices, the underlying libraries auto-configures
     read/write direction on read/write instructions.

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -162,5 +162,10 @@ class GPIO:
         """Convert a bitmask (integer) into a list pin indices."""
         return [i for i in range(8) if (mask & (1 << i))]
 
-    def supported_pins(self):
-        pass
+    def supported_write_pins(self) -> list[int]:
+        mask = self.manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask
+        return self._bitmask_to_pins(mask)
+
+    def supported_read_pins(self) -> list[int]:
+        mask = self.manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask
+        return self._bitmask_to_pins(mask)

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Literal, final
+from typing import TYPE_CHECKING, Literal, Protocol
 
 import PalmSens
 
@@ -29,6 +29,10 @@ def bitmask_to_pins(mask: int) -> list[int]:
     return [i for i in range(8) if (mask & (1 << i))]
 
 
+class HasCommProtocol(Protocol):
+    _comm: PalmSens.CommManager
+
+
 class GPIOBase:
     @property
     def _is_methodscript(self) -> bool:
@@ -44,8 +48,8 @@ class GPIOBase:
         -------
         list[int]
             Sorted list of pin numbers that can be used with
-            `write_pin`, `write_pins`, `toggle_pin`,
-            and `toggle_pins`.
+            `write`, `write_many`, `toggle`,
+            and `toggle_many`.
         """
         if not self._is_methodscript:
             raise GPIOError('Only supported on MethodSCRIPT devices.')
@@ -60,7 +64,7 @@ class GPIOBase:
         -------
         list[int]
             Sorted list of pin numbers that can be used with
-            `read_pin` and `read_pins`.
+            `read` and `read_many`.
         """
         if not self._is_methodscript:
             raise GPIOError('Only supported on MethodSCRIPT devices.')
@@ -89,7 +93,6 @@ class GPIOBase:
         )
 
 
-@final
 class GPIO(GPIOBase):
     """Digital general-purpose input/output (GPIO) interface.
 
@@ -112,7 +115,7 @@ class GPIO(GPIOBase):
     def __init__(self, manager: InstrumentManager):
         self._manager = manager
 
-    def read_pin(self, pin: int) -> Literal['low', 'high']:
+    def read(self, pin: int) -> Literal['low', 'high']:
         """Read the logic level of a single digital input pin.
 
         The pin configuration is automatically switched to input if needed.
@@ -134,10 +137,10 @@ class GPIO(GPIOBase):
         PinNotSupportedError:
             If ``pin`` is not a supported input pin.
         """
-        [level] = self.read_pins([pin])
+        [level] = self.read_many([pin])
         return level
 
-    def read_pins(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
+    def read_many(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
         """Read the logic levels of multiple digital input pins.
 
         Parameters
@@ -162,7 +165,6 @@ class GPIO(GPIOBase):
         mask = pins_to_bitmask(pins)
 
         with self._manager._lock():
-            # TODO: fix bug, this returns either returns all True or all False
             level_mask = self._manager._comm.ClientConnection.ReadDigitalLine(mask)
 
         levels = []
@@ -170,23 +172,21 @@ class GPIO(GPIOBase):
             pin_mask = 1 << pin
             levels.append(pin_mask & level_mask == pin_mask)
 
-        print(f'{level_mask=}, {mask=}, {levels=}')
+        return [('low', 'high')[level] for level in levels]
 
-        return levels
-
-    def _write_pins(self, pins: Sequence[int], func: Callable[[int, int], int]):
+    def _write_many(self, pins: Sequence[int], func: Callable[[int, int], int]):
         self._raise_if_pins_not_supported(pins, 'write')
 
         mask = pins_to_bitmask(pins)
 
         current = self._manager._comm.DigitalOutput
 
-        mask = func(mask, current)
+        level_mask = func(current, mask)
 
         with self._manager._lock():
-            self._manager._comm.ClientConnection.SetDigitalOutput(mask)
+            self._manager._comm.ClientConnection.SetDigitalOutput(level_mask)
 
-    def write_pins(self, pins: Sequence[int], level: Literal['low', 'high'] = 'high'):
+    def write_many(self, pins: Sequence[int], level: Literal['low', 'high'] = 'high'):
         """Set the logic level of multiple digital output pins.
 
         Parameters
@@ -206,16 +206,18 @@ class GPIO(GPIOBase):
 
             def func(current: int, mask: int) -> int:
                 return current | mask  # high
+
         elif level == 'low':
 
             def func(current: int, mask: int) -> int:
                 return current & ~mask  # low
+
         else:
             raise ValueError("`level` must be one of 'low' or 'high'")
 
-        return self._write_pins(pins, func)
+        return self._write_many(pins, func)
 
-    def write_pin(self, pin: int, level: Literal['low', 'high'] = 'high'):
+    def write(self, pin: int, level: Literal['low', 'high'] = 'high'):
         """Set the logic level of a single digital output pin.
 
         Parameters
@@ -230,9 +232,9 @@ class GPIO(GPIOBase):
         PinNotSupportedError:
             If ``pin`` is not a supported input pin.
         """
-        self.write_pins([pin], level=level)
+        self.write_many([pin], level=level)
 
-    def toggle_pin(self, pin: int):
+    def toggle(self, pin: int):
         """Invert the logic level of a single digital output pin.
 
         A ``high`` state becomes ``low`` and vice-versa.
@@ -251,9 +253,9 @@ class GPIO(GPIOBase):
         PinNotSupportedError
             If ``pin`` is not a supported output pin.
         """
-        return self.toggle_pins([pin])
+        return self.toggle_many([pin])
 
-    def toggle_pins(self, pins: Sequence[int]):
+    def toggle_many(self, pins: Sequence[int]):
         """Invert the logic level of multiple digital output pins.
 
         Each pin is toggled independently: ``high`` becomes ``low``
@@ -273,4 +275,4 @@ class GPIO(GPIOBase):
         def func(current: int, mask: int) -> int:
             return current ^ mask  # toggle
 
-        return self._write_pins(pins, func)
+        return self._write_many(pins, func)

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -24,6 +24,10 @@ class GPIO:
     def __init__(self, manager: InstrumentManager):
         self.manager = manager
 
+    @property
+    def _is_methodscript(self):
+        return (self.manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS)
+
     def read_pin(self, pin: int) -> Literal['low', 'high']:
         """Reads the state of a GPIO pin.
 
@@ -46,25 +50,9 @@ class GPIO:
 
     def read_pins(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
         """Read pins configured as input."""
-        if min(pins) < 0:
-            raise ValueError('Pin cannot be negative.')
+        self._raise_if_pins_not_supported(pins, 'read')
 
         mask = self._pins_to_bitmask(pins)
-
-        is_methodscript = isinstance(
-            self.manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
-        )
-
-        if is_methodscript:
-            supported_mask = (
-                self.manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask
-            )
-
-            if not (mask & supported_mask):
-                raise ValueError('Requested input pin is not supported by device.')
-        else:
-            if max(pins):
-                raise ValueError('Requested input pin is not supported by device.')
 
         with self.manager._lock():
             # TODO: fix bug, this returns either returns all True or all False
@@ -80,31 +68,15 @@ class GPIO:
         return levels
 
     def _write_pins(self, pins: Sequence[int], func: Callable[[int, int], int]):
-        if min(pins) < 0:
-            raise ValueError('Pin cannot be negative.')
+        self._raise_if_pins_not_supported(pins, 'write')
 
         mask = self._pins_to_bitmask(pins)
 
-        is_methodscript = isinstance(
-            self.manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
-        )
+        current = self.manager._comm.DigitalOutput
+
+        mask = func(mask, current)
 
         with self.manager._lock():
-            if is_methodscript:
-                supported_mask = self.manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask
-
-                if not (mask & supported_mask):
-                    raise ValueError('Requested output pin is not supported by device.')
-
-                current = self.manager._comm.ClientConnection.ReadDigitalLine(supported_mask)
-            else:
-                if max(pins) > 3:
-                    raise ValueError('Requested output pin is not supported by device.')
-
-                current = self.manager._comm.DigitalOutput
-
-            mask = func(mask, current)
-
             self.manager._comm.ClientConnection.SetDigitalOutput(mask)
 
     def write_pins(self, pins: Sequence[int], level: Literal['low', 'high'] = 'high'):
@@ -169,3 +141,24 @@ class GPIO:
     def supported_read_pins(self) -> list[int]:
         mask = self.manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask
         return self._bitmask_to_pins(mask)
+
+    def _raise_if_pins_not_supported(self, pins: Sequence[int], mode: Literal['read', 'write']):
+        if min(pins) < 0:
+            raise ValueError('Pin cannot be negative.')
+
+        if self._is_methodscript:
+            pin_mask = self._pins_to_bitmask(pins)
+            supported_mask = {
+                'write': self.manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask,
+                'read': self.manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask,
+            }[mode]
+
+            if pin_mask & supported_mask:
+                return
+        else:
+            if max(pins) < 4:
+                return
+
+        raise ValueError(
+            f'Requested {mode} pin is not supported by {self.manager.instrument.name}.'
+        )

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Literal, Protocol
+from typing import TYPE_CHECKING, Literal, final
 
 import PalmSens
 
@@ -29,71 +29,67 @@ def bitmask_to_pins(mask: int) -> list[int]:
     return [i for i in range(8) if (mask & (1 << i))]
 
 
-class HasCommProtocol(Protocol):
-    _comm: PalmSens.CommManager
+def is_methodscript(client_connection: PalmSens.Comm.ClientConnection) -> bool:
+    return isinstance(client_connection, PalmSens.Comm.ClientConnectionMS)
 
 
-class GPIOBase:
-    @property
-    def _is_methodscript(self) -> bool:
-        return isinstance(
-            self._manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
-        )
+def writable_pins(client_connection: PalmSens.Comm.ClientConnection) -> list[int]:
+    """Return the pin numbers that support digital output.
 
-    @property
-    def writable_pins(self) -> list[int]:
-        """Return the pin numbers that support digital output.
-
-        Returns
-        -------
-        list[int]
-            Sorted list of pin numbers that can be used with
-            `write`, `write_many`, `toggle`,
-            and `toggle_many`.
-        """
-        if not self._is_methodscript:
-            raise GPIOError('Only supported on MethodSCRIPT devices.')
-        mask = self._manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask
-        return bitmask_to_pins(mask)
-
-    @property
-    def readable_pins(self) -> list[int]:
-        """Return the pin numbers that support digital input.
-
-        Returns
-        -------
-        list[int]
-            Sorted list of pin numbers that can be used with
-            `read` and `read_many`.
-        """
-        if not self._is_methodscript:
-            raise GPIOError('Only supported on MethodSCRIPT devices.')
-        mask = self._manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask
-        return bitmask_to_pins(mask)
-
-    def _raise_if_pins_not_supported(self, pins: Sequence[int], mode: Literal['read', 'write']):
-        if min(pins) < 0:
-            raise PinNotSupportedError('Pin cannot be negative.')
-
-        if self._is_methodscript:
-            pin_mask = pins_to_bitmask(pins)
-            supported_mask = {
-                'write': self._manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask,
-                'read': self._manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask,
-            }[mode]
-
-            if pin_mask & supported_mask:
-                return
-        else:
-            if max(pins) < 4:
-                return
-
-        raise PinNotSupportedError(
-            f'Requested {mode} pin is not supported by {self._manager.instrument.name}.'
-        )
+    Returns
+    -------
+    list[int]
+        Sorted list of pin numbers that can be used with
+        `write`, `write_many`, `toggle`,
+        and `toggle_many`.
+    """
+    if not is_methodscript(client_connection):
+        raise GPIOError('Only supported on MethodSCRIPT devices.')
+    mask = client_connection.Capabilities.SupportedDigitalOutputLineMask
+    return bitmask_to_pins(mask)
 
 
-class GPIO(GPIOBase):
+def readable_pins(client_connection: PalmSens.Comm.ClientConnection) -> list[int]:
+    """Return the pin numbers that support digital input.
+
+    Returns
+    -------
+    list[int]
+        Sorted list of pin numbers that can be used with
+        `read` and `read_many`.
+    """
+    if not is_methodscript(client_connection):
+        raise GPIOError('Only supported on MethodSCRIPT devices.')
+    mask = client_connection.Capabilities.SupportedDigitalInputLineMask
+    return bitmask_to_pins(mask)
+
+
+def raise_if_pins_not_supported(
+    client_connection: PalmSens.Comm.ClientConnection,
+    pins: Sequence[int],
+    mode: Literal['read', 'write'],
+):
+    if min(pins) < 0:
+        raise PinNotSupportedError('Pin cannot be negative.')
+
+    if is_methodscript(client_connection):
+        pin_mask = pins_to_bitmask(pins)
+        supported_mask = {
+            'write': client_connection.Capabilities.SupportedDigitalOutputLineMask,
+            'read': client_connection.Capabilities.SupportedDigitalInputLineMask,
+        }[mode]
+
+        if pin_mask & supported_mask:
+            return
+    else:
+        if max(pins) < 4:
+            return
+
+    raise PinNotSupportedError(f'Requested {mode} pin is not supported by device.')
+
+
+@final
+class GPIO:
     """Digital general-purpose input/output (GPIO) interface.
 
     This class provides high-level access to the instrument's digital
@@ -160,7 +156,9 @@ class GPIO(GPIOBase):
         PinNotSupportedError
             If any pin in ``pins`` is not a supported input pin.
         """
-        self._raise_if_pins_not_supported(pins, 'read')
+        raise_if_pins_not_supported(
+            self._manager._comm.ClientConnection, pins=pins, mode='read'
+        )
 
         mask = pins_to_bitmask(pins)
 
@@ -175,7 +173,9 @@ class GPIO(GPIOBase):
         return [('low', 'high')[level] for level in levels]
 
     def _write_many(self, pins: Sequence[int], func: Callable[[int, int], int]):
-        self._raise_if_pins_not_supported(pins, 'write')
+        raise_if_pins_not_supported(
+            self._manager._comm.ClientConnection, pins=pins, mode='write'
+        )
 
         mask = pins_to_bitmask(pins)
 
@@ -276,3 +276,28 @@ class GPIO(GPIOBase):
             return current ^ mask  # toggle
 
         return self._write_many(pins, func)
+
+    @property
+    def writable_pins(self) -> list[int]:
+        """Return the pin numbers that support digital output.
+
+        Returns
+        -------
+        list[int]
+            Sorted list of pin numbers that can be used with
+            `write`, `write_many`, `toggle`,
+            and `toggle_many`.
+        """
+        return writable_pins(self._manager._comm.ClientConnection)
+
+    @property
+    def readable_pins(self) -> list[int]:
+        """Return the pin numbers that support digital input.
+
+        Returns
+        -------
+        list[int]
+            Sorted list of pin numbers that can be used with
+            `read` and `read_many`.
+        """
+        return readable_pins(self._manager._comm.ClientConnection)

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -25,8 +25,8 @@ class GPIO:
         self.manager = manager
 
     @property
-    def _is_methodscript(self):
-        return (self.manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS)
+    def _is_methodscript(self) -> bool:
+        return isinstance(self.manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS)
 
     def read_pin(self, pin: int) -> Literal['low', 'high']:
         """Reads the state of a GPIO pin.

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -75,14 +75,16 @@ def raise_if_pins_not_supported(
         if pin_mask & supported_mask:
             return
     else:
-        if max(pins) < 4:
+        if mode == 'read' and max(pins) < 1:
+            return
+        if mode == 'write' and max(pins) < 4:
             return
 
     raise PinNotSupportedError(f'Requested {mode} pin is not supported by device.')
 
 
 @final
-class GPIO:
+class Gpio:
     """Digital general-purpose input/output (GPIO) interface.
 
     This class provides high-level access to the instrument's digital
@@ -98,8 +100,8 @@ class GPIO:
 
     For explicit control, use the low-level MethodSCRIPT primitives directly:
 
-        - [pypalmsens.CommProtocol][]
-        - [MethodSCRIPT manual](https://dev.palmsens.com/methodscript/latest/methodscript/methodscript_main.html)
+    - [pypalmsens.CommProtocol][]
+    - [MethodSCRIPT manual](https://dev.palmsens.com/methodscript/latest/methodscript/methodscript_main.html)
     """
 
     def __init__(self, manager: InstrumentManager):

--- a/python/src/pypalmsens/_instruments/gpio_async.py
+++ b/python/src/pypalmsens/_instruments/gpio_async.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Literal, final
 
-from .gpio import GPIOBase, pins_to_bitmask
+from .gpio import pins_to_bitmask, raise_if_pins_not_supported, readable_pins, writable_pins
 from .shared import create_future
 
 if TYPE_CHECKING:
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 @final
-class GPIOAsync(GPIOBase):
+class GPIOAsync:
     """Digital general-purpose input/output (GPIO) interface.
 
     This class provides high-level access to the instrument's digital
@@ -78,7 +78,9 @@ class GPIOAsync(GPIOBase):
         PinNotSupportedError
             If any pin in ``pins`` is not a supported input pin.
         """
-        self._raise_if_pins_not_supported(pins, 'read')
+        raise_if_pins_not_supported(
+            self._manager._comm.ClientConnection, pins=pins, mode='read'
+        )
 
         mask = pins_to_bitmask(pins)
 
@@ -95,7 +97,9 @@ class GPIOAsync(GPIOBase):
         return [('low', 'high')[level] for level in levels]
 
     async def _write_many(self, pins: Sequence[int], func: Callable[[int, int], int]):
-        self._raise_if_pins_not_supported(pins, 'write')
+        raise_if_pins_not_supported(
+            self._manager._comm.ClientConnection, pins=pins, mode='write'
+        )
 
         mask = pins_to_bitmask(pins)
 
@@ -128,10 +132,12 @@ class GPIOAsync(GPIOBase):
 
             def func(current: int, mask: int) -> int:
                 return current | mask  # high
+
         elif level == 'low':
 
             def func(current: int, mask: int) -> int:
                 return current & ~mask  # low
+
         else:
             raise ValueError("`level` must be one of 'low' or 'high'")
 
@@ -196,3 +202,28 @@ class GPIOAsync(GPIOBase):
             return current ^ mask  # toggle
 
         return await self._write_many(pins, func)
+
+    @property
+    def writable_pins(self) -> list[int]:
+        """Return the pin numbers that support digital output.
+
+        Returns
+        -------
+        list[int]
+            Sorted list of pin numbers that can be used with
+            `write`, `write_many`, `toggle`,
+            and `toggle_many`.
+        """
+        return writable_pins(self._manager._comm.ClientConnection)
+
+    @property
+    def readable_pins(self) -> list[int]:
+        """Return the pin numbers that support digital input.
+
+        Returns
+        -------
+        list[int]
+            Sorted list of pin numbers that can be used with
+            `read` and `read_many`.
+        """
+        return readable_pins(self._manager._comm.ClientConnection)

--- a/python/src/pypalmsens/_instruments/gpio_async.py
+++ b/python/src/pypalmsens/_instruments/gpio_async.py
@@ -3,94 +3,15 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Literal, final
 
-import PalmSens
+from .gpio import GPIOBase, pins_to_bitmask
+from .shared import create_future
 
 if TYPE_CHECKING:
-    from .instrument_manager import InstrumentManager
-
-
-class GPIOError(ValueError): ...
-
-
-class PinNotSupportedError(GPIOError): ...
-
-
-def pins_to_bitmask(pins: Sequence[int]) -> int:
-    """Convert a list of pin indices into a bitmask (integer)."""
-    mask = 0
-    for pin in pins:
-        mask |= 1 << pin
-
-    return mask
-
-
-def bitmask_to_pins(mask: int) -> list[int]:
-    """Convert a bitmask (integer) into a list pin indices."""
-    return [i for i in range(8) if (mask & (1 << i))]
-
-
-class GPIOBase:
-    @property
-    def _is_methodscript(self) -> bool:
-        return isinstance(
-            self._manager._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
-        )
-
-    @property
-    def writable_pins(self) -> list[int]:
-        """Return the pin numbers that support digital output.
-
-        Returns
-        -------
-        list[int]
-            Sorted list of pin numbers that can be used with
-            `write_pin`, `write_pins`, `toggle_pin`,
-            and `toggle_pins`.
-        """
-        if not self._is_methodscript:
-            raise GPIOError('Only supported on MethodSCRIPT devices.')
-        mask = self._manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask
-        return bitmask_to_pins(mask)
-
-    @property
-    def readable_pins(self) -> list[int]:
-        """Return the pin numbers that support digital input.
-
-        Returns
-        -------
-        list[int]
-            Sorted list of pin numbers that can be used with
-            `read_pin` and `read_pins`.
-        """
-        if not self._is_methodscript:
-            raise GPIOError('Only supported on MethodSCRIPT devices.')
-        mask = self._manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask
-        return bitmask_to_pins(mask)
-
-    def _raise_if_pins_not_supported(self, pins: Sequence[int], mode: Literal['read', 'write']):
-        if min(pins) < 0:
-            raise PinNotSupportedError('Pin cannot be negative.')
-
-        if self._is_methodscript:
-            pin_mask = pins_to_bitmask(pins)
-            supported_mask = {
-                'write': self._manager._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask,
-                'read': self._manager._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask,
-            }[mode]
-
-            if pin_mask & supported_mask:
-                return
-        else:
-            if max(pins) < 4:
-                return
-
-        raise PinNotSupportedError(
-            f'Requested {mode} pin is not supported by {self._manager.instrument.name}.'
-        )
+    from .instrument_manager_async import InstrumentManagerAsync
 
 
 @final
-class GPIO(GPIOBase):
+class GPIOAsync(GPIOBase):
     """Digital general-purpose input/output (GPIO) interface.
 
     This class provides high-level access to the instrument's digital
@@ -109,10 +30,10 @@ class GPIO(GPIOBase):
         - [MethodSCRIPT manual](https://dev.palmsens.com/methodscript/latest/methodscript/methodscript_main.html)
     """
 
-    def __init__(self, manager: InstrumentManager):
+    def __init__(self, manager: InstrumentManagerAsync):
         self._manager = manager
 
-    def read_pin(self, pin: int) -> Literal['low', 'high']:
+    async def read_pin(self, pin: int) -> Literal['low', 'high']:
         """Read the logic level of a single digital input pin.
 
         The pin configuration is automatically switched to input if needed.
@@ -134,10 +55,10 @@ class GPIO(GPIOBase):
         PinNotSupportedError:
             If ``pin`` is not a supported input pin.
         """
-        [level] = self.read_pins([pin])
+        [level] = await self.read_pins([pin])
         return level
 
-    def read_pins(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
+    async def read_pins(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
         """Read the logic levels of multiple digital input pins.
 
         Parameters
@@ -161,9 +82,11 @@ class GPIO(GPIOBase):
 
         mask = pins_to_bitmask(pins)
 
-        with self._manager._lock():
+        async with self._manager._lock():
             # TODO: fix bug, this returns either returns all True or all False
-            level_mask = self._manager._comm.ClientConnection.ReadDigitalLine(mask)
+            level_mask = await create_future(
+                self._manager._comm.ClientConnection.ReadDigitalLineAsync(mask)
+            )
 
         levels = []
         for pin in pins:
@@ -174,7 +97,7 @@ class GPIO(GPIOBase):
 
         return levels
 
-    def _write_pins(self, pins: Sequence[int], func: Callable[[int, int], int]):
+    async def _write_pins(self, pins: Sequence[int], func: Callable[[int, int], int]):
         self._raise_if_pins_not_supported(pins, 'write')
 
         mask = pins_to_bitmask(pins)
@@ -183,10 +106,12 @@ class GPIO(GPIOBase):
 
         mask = func(mask, current)
 
-        with self._manager._lock():
-            self._manager._comm.ClientConnection.SetDigitalOutput(mask)
+        async with self._manager._lock():
+            await create_future(
+                self._manager._comm.ClientConnection.SetDigitalOutputAsync(mask)
+            )
 
-    def write_pins(self, pins: Sequence[int], level: Literal['low', 'high'] = 'high'):
+    async def write_pins(self, pins: Sequence[int], level: Literal['low', 'high'] = 'high'):
         """Set the logic level of multiple digital output pins.
 
         Parameters
@@ -213,9 +138,9 @@ class GPIO(GPIOBase):
         else:
             raise ValueError("`level` must be one of 'low' or 'high'")
 
-        return self._write_pins(pins, func)
+        return await self._write_pins(pins, func)
 
-    def write_pin(self, pin: int, level: Literal['low', 'high'] = 'high'):
+    async def write_pin(self, pin: int, level: Literal['low', 'high'] = 'high'):
         """Set the logic level of a single digital output pin.
 
         Parameters
@@ -230,9 +155,9 @@ class GPIO(GPIOBase):
         PinNotSupportedError:
             If ``pin`` is not a supported input pin.
         """
-        self.write_pins([pin], level=level)
+        _ = await self.write_pins([pin], level=level)
 
-    def toggle_pin(self, pin: int):
+    async def toggle_pin(self, pin: int):
         """Invert the logic level of a single digital output pin.
 
         A ``high`` state becomes ``low`` and vice-versa.
@@ -251,9 +176,9 @@ class GPIO(GPIOBase):
         PinNotSupportedError
             If ``pin`` is not a supported output pin.
         """
-        return self.toggle_pins([pin])
+        return await self.toggle_pins([pin])
 
-    def toggle_pins(self, pins: Sequence[int]):
+    async def toggle_pins(self, pins: Sequence[int]):
         """Invert the logic level of multiple digital output pins.
 
         Each pin is toggled independently: ``high`` becomes ``low``
@@ -273,4 +198,4 @@ class GPIO(GPIOBase):
         def func(current: int, mask: int) -> int:
             return current ^ mask  # toggle
 
-        return self._write_pins(pins, func)
+        return await self._write_pins(pins, func)

--- a/python/src/pypalmsens/_instruments/gpio_async.py
+++ b/python/src/pypalmsens/_instruments/gpio_async.py
@@ -33,7 +33,7 @@ class GPIOAsync(GPIOBase):
     def __init__(self, manager: InstrumentManagerAsync):
         self._manager = manager
 
-    async def read_pin(self, pin: int) -> Literal['low', 'high']:
+    async def read(self, pin: int) -> Literal['low', 'high']:
         """Read the logic level of a single digital input pin.
 
         The pin configuration is automatically switched to input if needed.
@@ -55,10 +55,10 @@ class GPIOAsync(GPIOBase):
         PinNotSupportedError:
             If ``pin`` is not a supported input pin.
         """
-        [level] = await self.read_pins([pin])
+        [level] = await self.read_many([pin])
         return level
 
-    async def read_pins(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
+    async def read_many(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
         """Read the logic levels of multiple digital input pins.
 
         Parameters
@@ -83,8 +83,7 @@ class GPIOAsync(GPIOBase):
         mask = pins_to_bitmask(pins)
 
         async with self._manager._lock():
-            # TODO: fix bug, this returns either returns all True or all False
-            level_mask = await create_future(
+            level_mask: int = await create_future(
                 self._manager._comm.ClientConnection.ReadDigitalLineAsync(mask)
             )
 
@@ -93,11 +92,9 @@ class GPIOAsync(GPIOBase):
             pin_mask = 1 << pin
             levels.append(pin_mask & level_mask == pin_mask)
 
-        print(f'{level_mask=}, {mask=}, {levels=}')
+        return [('low', 'high')[level] for level in levels]
 
-        return levels
-
-    async def _write_pins(self, pins: Sequence[int], func: Callable[[int, int], int]):
+    async def _write_many(self, pins: Sequence[int], func: Callable[[int, int], int]):
         self._raise_if_pins_not_supported(pins, 'write')
 
         mask = pins_to_bitmask(pins)
@@ -111,7 +108,7 @@ class GPIOAsync(GPIOBase):
                 self._manager._comm.ClientConnection.SetDigitalOutputAsync(mask)
             )
 
-    async def write_pins(self, pins: Sequence[int], level: Literal['low', 'high'] = 'high'):
+    async def write_many(self, pins: Sequence[int], level: Literal['low', 'high'] = 'high'):
         """Set the logic level of multiple digital output pins.
 
         Parameters
@@ -138,9 +135,9 @@ class GPIOAsync(GPIOBase):
         else:
             raise ValueError("`level` must be one of 'low' or 'high'")
 
-        return await self._write_pins(pins, func)
+        return await self._write_many(pins, func)
 
-    async def write_pin(self, pin: int, level: Literal['low', 'high'] = 'high'):
+    async def write(self, pin: int, level: Literal['low', 'high'] = 'high'):
         """Set the logic level of a single digital output pin.
 
         Parameters
@@ -155,9 +152,9 @@ class GPIOAsync(GPIOBase):
         PinNotSupportedError:
             If ``pin`` is not a supported input pin.
         """
-        _ = await self.write_pins([pin], level=level)
+        _ = await self.write_many([pin], level=level)
 
-    async def toggle_pin(self, pin: int):
+    async def toggle(self, pin: int):
         """Invert the logic level of a single digital output pin.
 
         A ``high`` state becomes ``low`` and vice-versa.
@@ -176,9 +173,9 @@ class GPIOAsync(GPIOBase):
         PinNotSupportedError
             If ``pin`` is not a supported output pin.
         """
-        return await self.toggle_pins([pin])
+        return await self.toggle_many([pin])
 
-    async def toggle_pins(self, pins: Sequence[int]):
+    async def toggle_many(self, pins: Sequence[int]):
         """Invert the logic level of multiple digital output pins.
 
         Each pin is toggled independently: ``high`` becomes ``low``
@@ -198,4 +195,4 @@ class GPIOAsync(GPIOBase):
         def func(current: int, mask: int) -> int:
             return current ^ mask  # toggle
 
-        return await self._write_pins(pins, func)
+        return await self._write_many(pins, func)

--- a/python/src/pypalmsens/_instruments/gpio_async.py
+++ b/python/src/pypalmsens/_instruments/gpio_async.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 @final
-class GPIOAsync:
+class GpioAsync:
     """Digital general-purpose input/output (GPIO) interface.
 
     This class provides high-level access to the instrument's digital
@@ -26,14 +26,14 @@ class GPIOAsync:
 
     For explicit control, use the low-level MethodSCRIPT primitives directly:
 
-        - [pypalmsens.CommProtocol][]
-        - [MethodSCRIPT manual](https://dev.palmsens.com/methodscript/latest/methodscript/methodscript_main.html)
+    - [pypalmsens.CommProtocol][]
+    - [MethodSCRIPT manual](https://dev.palmsens.com/methodscript/latest/methodscript/methodscript_main.html)
     """
 
     def __init__(self, manager: InstrumentManagerAsync):
         self._manager = manager
 
-    async def read(self, pin: int) -> Literal['low', 'high']:
+    async def read_async(self, pin: int) -> Literal['low', 'high']:
         """Read the logic level of a single digital input pin.
 
         The pin configuration is automatically switched to input if needed.
@@ -55,10 +55,10 @@ class GPIOAsync:
         PinNotSupportedError:
             If ``pin`` is not a supported input pin.
         """
-        [level] = await self.read_many([pin])
+        [level] = await self.read_many_async([pin])
         return level
 
-    async def read_many(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
+    async def read_many_async(self, pins: Sequence[int]) -> list[Literal['low', 'high']]:
         """Read the logic levels of multiple digital input pins.
 
         Parameters
@@ -96,7 +96,7 @@ class GPIOAsync:
 
         return [('low', 'high')[level] for level in levels]
 
-    async def _write_many(self, pins: Sequence[int], func: Callable[[int, int], int]):
+    async def _write_many_async(self, pins: Sequence[int], func: Callable[[int, int], int]):
         raise_if_pins_not_supported(
             self._manager._comm.ClientConnection, pins=pins, mode='write'
         )
@@ -112,7 +112,9 @@ class GPIOAsync:
                 self._manager._comm.ClientConnection.SetDigitalOutputAsync(mask)
             )
 
-    async def write_many(self, pins: Sequence[int], level: Literal['low', 'high'] = 'high'):
+    async def write_many_async(
+        self, pins: Sequence[int], level: Literal['low', 'high'] = 'high'
+    ):
         """Set the logic level of multiple digital output pins.
 
         Parameters
@@ -141,9 +143,9 @@ class GPIOAsync:
         else:
             raise ValueError("`level` must be one of 'low' or 'high'")
 
-        return await self._write_many(pins, func)
+        return await self._write_many_async(pins, func)
 
-    async def write(self, pin: int, level: Literal['low', 'high'] = 'high'):
+    async def write_async(self, pin: int, level: Literal['low', 'high'] = 'high'):
         """Set the logic level of a single digital output pin.
 
         Parameters
@@ -158,9 +160,9 @@ class GPIOAsync:
         PinNotSupportedError:
             If ``pin`` is not a supported input pin.
         """
-        _ = await self.write_many([pin], level=level)
+        _ = await self.write_many_async([pin], level=level)
 
-    async def toggle(self, pin: int):
+    async def toggle_async(self, pin: int):
         """Invert the logic level of a single digital output pin.
 
         A ``high`` state becomes ``low`` and vice-versa.
@@ -179,9 +181,9 @@ class GPIOAsync:
         PinNotSupportedError
             If ``pin`` is not a supported output pin.
         """
-        return await self.toggle_many([pin])
+        return await self.toggle_many_async([pin])
 
-    async def toggle_many(self, pins: Sequence[int]):
+    async def toggle_many_async(self, pins: Sequence[int]):
         """Invert the logic level of multiple digital output pins.
 
         Each pin is toggled independently: ``high`` becomes ``low``
@@ -201,7 +203,7 @@ class GPIOAsync:
         def func(current: int, mask: int) -> int:
             return current ^ mask  # toggle
 
-        return await self._write_many(pins, func)
+        return await self._write_many_async(pins, func)
 
     @property
     def writable_pins(self) -> list[int]:

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -31,7 +31,7 @@ from .callback import Callback, CallbackEIS, Status
 from .capabilities_mixin import CapabilitiesMixin
 from .comm_protocol import CommProtocol
 from .events_mixin import EventsMixin
-from .gpio import GPIO
+from .gpio import Gpio
 from .instrument import Instrument, discover
 from .measurement_manager_async import MeasurementManagerAsync
 from .shared import firmware_warning
@@ -130,9 +130,10 @@ class InstrumentManager(CapabilitiesMixin, EventsMixin):
         self.instrument: Instrument = instrument
         """Instrument being managed by this class."""
 
-        self._comm: CommManager
+        self.gpio: Gpio = Gpio(self)
+        """High-level GPIO interface."""
 
-        self.gpio: GPIO = GPIO(self)
+        self._comm: CommManager
 
     @override
     def __repr__(self):

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -31,6 +31,7 @@ from .callback import Callback, CallbackEIS, Status
 from .capabilities_mixin import CapabilitiesMixin
 from .comm_protocol import CommProtocol
 from .events_mixin import EventsMixin
+from .gpio import GPIO
 from .instrument import Instrument, discover
 from .measurement_manager_async import MeasurementManagerAsync
 from .shared import firmware_warning
@@ -130,6 +131,8 @@ class InstrumentManager(CapabilitiesMixin, EventsMixin):
         """Instrument being managed by this class."""
 
         self._comm: CommManager
+
+        self.gpio: GPIO = GPIO(self)
 
     @override
     def __repr__(self):
@@ -537,101 +540,6 @@ class InstrumentManager(CapabilitiesMixin, EventsMixin):
         """
         with self._lock():
             self._comm.ClientConnection.SetMuxChannel(channel)
-
-    def gpio_read_pin(self, pin: int) -> Literal['low', 'high']:
-        """Reads the state of a GPIO pin.
-
-        Check your device documentation for the available input pins.
-
-        Parameters
-        ----------
-        pin: integer
-            The integer index of the GPIO pin to read.
-
-        Raises
-        ------
-        ValueError:
-            If the requested output pin is not supported by the device.
-        """
-        if pin < 0:
-            raise ValueError('Pin cannot be negative.')
-
-        mask = 1 << pin
-
-        is_methodscript = isinstance(
-            self._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
-        )
-
-        if is_methodscript:
-            supported_mask = (
-                self._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask
-            )
-
-            if not (mask & supported_mask):
-                raise ValueError('Requested input pin is not supported by device.')
-        else:
-            if pin > 1:
-                raise ValueError('Requested input pin is not supported by device.')
-
-        with self._lock():
-            level = self._comm.ClientConnection.ReadDigitalLine(mask)
-
-        return ('low', 'high')[level]
-
-    def gpio_write_pin(self, pin: int, level: Literal['low', 'high', 'toggle'] = 'high'):
-        """Writes a specified state to a GPIO pin.
-
-        Check your device documentation for available output pins.
-
-        Parameters
-        ----------
-        pin: integer
-            The integer index of the GPIO pin to control.
-        level: Literal['low', 'high', 'toggle']
-            The desired output level. Must be one of 'low', 'high', or 'toggle'.
-            Defaults to 'high'.
-
-        Raises
-        ------
-        ValueError:
-            If the requested output pin is not supported by the device,
-            or if an invalid value is provided for `level`.
-        """
-        if pin < 0:
-            raise ValueError('Pin cannot be negative.')
-
-        bit = 1 << pin
-
-        is_methodscript = isinstance(
-            self._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
-        )
-
-        with self._lock():
-            if is_methodscript:
-                supported_mask = (
-                    self._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask
-                )
-
-                if not (bit & supported_mask):
-                    raise ValueError('Requested output pin is not supported by device.')
-
-                current = self._comm.ClientConnection.ReadDigitalLine(supported_mask)
-            else:
-                if pin > 4:
-                    raise ValueError('Requested output pin is not supported by device.')
-
-                current = self._comm.DigitalOutput
-
-            if level == 'high':
-                mask = current | bit  # high
-            elif level == 'low':
-                mask = current & ~bit  # low
-            elif level == 'toggle':
-                mask = current ^ bit  # toggle
-            else:
-                raise ValueError("`level` must be one of 'low', 'high', 'toggle'")
-
-            self._comm.ClientConnection.SetDigitalOutput(mask)
 
     def disconnect(self):
         """Disconnect from the instrument."""

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -538,6 +538,55 @@ class InstrumentManager(CapabilitiesMixin, EventsMixin):
         with self._lock():
             self._comm.ClientConnection.SetMuxChannel(channel)
 
+    def gpio_read_pin(self, pin: int) -> float:
+        # NonMS : Commands.ReadDigitalLine
+        # MS : CommandsMS.ReadDigitalLine
+
+        if pin < 0:
+            raise ValueError('Pin cannot be negative.')
+
+        mask = 1 << pin
+
+        is_methodscript = isinstance(
+            self._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
+        )
+
+        if is_methodscript:
+            supported_mask = (
+                self._comm.ClientConnection.Capabilities.SupportedDigitalInputLineMask
+            )
+
+            if not (mask & supported_mask):
+                raise ValueError('Requested pin is not supported by device.')
+        else:
+            if mask > 2:
+                raise ValueError('Requested pin is not supported by device.')
+
+        return self._comm.DigitalLine(mask)
+
+    def gpio_write_pin(self, pin: int, level=Literal['low', 'high']):
+        if pin < 0:
+            raise ValueError('Pin cannot be negative.')
+
+        mask = 1 << pin
+
+        is_methodscript = isinstance(
+            self._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
+        )
+
+        if is_methodscript:
+            supported_mask = (
+                self._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask
+            )
+
+            if not (mask & supported_mask):
+                raise ValueError('Requested pin is not supported by device.')
+        else:
+            if mask > 8:
+                raise ValueError('Requested pin is not supported by device.')
+
+        self._comm.ClientConnection.SetDigitalOutput(mask)
+
     def disconnect(self):
         """Disconnect from the instrument."""
         if not self.is_connected():

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -538,10 +538,21 @@ class InstrumentManager(CapabilitiesMixin, EventsMixin):
         with self._lock():
             self._comm.ClientConnection.SetMuxChannel(channel)
 
-    def gpio_read_pin(self, pin: int) -> float:
-        # NonMS : Commands.ReadDigitalLine
-        # MS : CommandsMS.ReadDigitalLine
+    def gpio_read_pin(self, pin: int) -> Literal['low', 'high']:
+        """Reads the state of a GPIO pin.
 
+        Check your device documentation for the available input pins.
+
+        Parameters
+        ----------
+        pin: integer
+            The integer index of the GPIO pin to read.
+
+        Raises
+        ------
+        ValueError:
+            If the requested output pin is not supported by the device.
+        """
         if pin < 0:
             raise ValueError('Pin cannot be negative.')
 
@@ -557,35 +568,70 @@ class InstrumentManager(CapabilitiesMixin, EventsMixin):
             )
 
             if not (mask & supported_mask):
-                raise ValueError('Requested pin is not supported by device.')
+                raise ValueError('Requested input pin is not supported by device.')
         else:
-            if mask > 2:
-                raise ValueError('Requested pin is not supported by device.')
+            if pin > 1:
+                raise ValueError('Requested input pin is not supported by device.')
 
-        return self._comm.DigitalLine(mask)
+        with self._lock():
+            level = self._comm.ClientConnection.ReadDigitalLine(mask)
 
-    def gpio_write_pin(self, pin: int, level=Literal['low', 'high']):
+        return ('low', 'high')[level]
+
+    def gpio_write_pin(self, pin: int, level: Literal['low', 'high', 'toggle'] = 'high'):
+        """Writes a specified state to a GPIO pin.
+
+        Check your device documentation for available output pins.
+
+        Parameters
+        ----------
+        pin: integer
+            The integer index of the GPIO pin to control.
+        level: Literal['low', 'high', 'toggle']
+            The desired output level. Must be one of 'low', 'high', or 'toggle'.
+            Defaults to 'high'.
+
+        Raises
+        ------
+        ValueError:
+            If the requested output pin is not supported by the device,
+            or if an invalid value is provided for `level`.
+        """
         if pin < 0:
             raise ValueError('Pin cannot be negative.')
 
-        mask = 1 << pin
+        bit = 1 << pin
 
         is_methodscript = isinstance(
             self._comm.ClientConnection, PalmSens.Comm.ClientConnectionMS
         )
 
-        if is_methodscript:
-            supported_mask = (
-                self._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask
-            )
+        with self._lock():
+            if is_methodscript:
+                supported_mask = (
+                    self._comm.ClientConnection.Capabilities.SupportedDigitalOutputLineMask
+                )
 
-            if not (mask & supported_mask):
-                raise ValueError('Requested pin is not supported by device.')
-        else:
-            if mask > 8:
-                raise ValueError('Requested pin is not supported by device.')
+                if not (bit & supported_mask):
+                    raise ValueError('Requested output pin is not supported by device.')
 
-        self._comm.ClientConnection.SetDigitalOutput(mask)
+                current = self._comm.ClientConnection.ReadDigitalLine(supported_mask)
+            else:
+                if pin > 4:
+                    raise ValueError('Requested output pin is not supported by device.')
+
+                current = self._comm.DigitalOutput
+
+            if level == 'high':
+                mask = current | bit  # high
+            elif level == 'low':
+                mask = current & ~bit  # low
+            elif level == 'toggle':
+                mask = current ^ bit  # toggle
+            else:
+                raise ValueError("`level` must be one of 'low', 'high', 'toggle'")
+
+            self._comm.ClientConnection.SetDigitalOutput(mask)
 
     def disconnect(self):
         """Disconnect from the instrument."""

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -32,7 +32,7 @@ from .callback import Callback, CallbackEIS, CallbackStatus, Status
 from .capabilities_mixin import CapabilitiesMixin
 from .comm_protocol_async import CommProtocolAsync
 from .events_mixin import EventsMixin
-from .gpio_async import GPIOAsync
+from .gpio_async import GpioAsync
 from .instrument import Instrument, discover_async
 from .measurement_manager_async import MeasurementManagerAsync
 from .shared import create_future, firmware_warning
@@ -129,11 +129,12 @@ class InstrumentManagerAsync(CapabilitiesMixin, EventsMixin):
         self.instrument: Instrument = instrument
         """Instrument being managed by this class."""
 
+        self.gpio: GpioAsync = GpioAsync(self)
+        """High-level GPIO interface."""
+
         self._comm: CommManager
         self._status_callback: CallbackStatus
         self._loop: asyncio.AbstractEventLoop
-
-        self.gpio: GPIOAsync = GPIOAsync(self)
 
     @override
     def __repr__(self):

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -32,6 +32,7 @@ from .callback import Callback, CallbackEIS, CallbackStatus, Status
 from .capabilities_mixin import CapabilitiesMixin
 from .comm_protocol_async import CommProtocolAsync
 from .events_mixin import EventsMixin
+from .gpio_async import GPIOAsync
 from .instrument import Instrument, discover_async
 from .measurement_manager_async import MeasurementManagerAsync
 from .shared import create_future, firmware_warning
@@ -131,6 +132,8 @@ class InstrumentManagerAsync(CapabilitiesMixin, EventsMixin):
         self._comm: CommManager
         self._status_callback: CallbackStatus
         self._loop: asyncio.AbstractEventLoop
+
+        self.gpio: GPIOAsync = GPIOAsync(self)
 
     @override
     def __repr__(self):

--- a/python/tests/test_gpio.py
+++ b/python/tests/test_gpio.py
@@ -54,6 +54,7 @@ def test_bitmask_to_pins(mask, expected_pins):
     assert gpio.bitmask_to_pins(mask) == expected_pins
 
 
+@pytest.mark.instrument
 def test_raise_if_not_supported(manager):
     client = manager._comm.ClientConnection
 
@@ -76,18 +77,21 @@ def test_raise_if_not_supported(manager):
     gpio.raise_if_pins_not_supported(client, write_pins, mode='write')
 
 
+@pytest.mark.instrument
 def test_readable_pins(manager):
     pins = manager.gpio.readable_pins
     assert pins
     assert all(isinstance(val, int) for val in pins)
 
 
+@pytest.mark.instrument
 def test_writable_pins(manager):
     pins = manager.gpio.writable_pins
     assert pins
     assert all(isinstance(val, int) for val in pins)
 
 
+@pytest.mark.instrument
 def test_read(manager):
     pins = manager.gpio.readable_pins
 
@@ -101,6 +105,7 @@ def test_read(manager):
         _ = manager.gpio.read(1234)
 
 
+@pytest.mark.instrument
 def test_write(manager):
     pins = manager.gpio.writable_pins
 

--- a/python/tests/test_gpio.py
+++ b/python/tests/test_gpio.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+import pytest_asyncio
+
+import pypalmsens as ps
+from pypalmsens._instruments import gpio
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='module')
+def manager():
+    instrument, *_ = ps.discover()
+    with ps.connect(instrument) as mgr:
+        logger.warning('Connected to %s', mgr.instrument.id)
+        yield mgr
+
+
+@pytest_asyncio.fixture(scope='module')
+async def manager_async():
+    instrument, *_ = await ps.discover_async()
+    async with await ps.connect_async(instrument) as mgr:
+        logger.warning('Connected to %s', mgr.instrument.id)
+        yield mgr
+
+
+@pytest.mark.parametrize(
+    'pins,expected_mask',
+    (
+        ([0], 1),
+        ([1, 3, 5], 42),
+        ([1, 1, 1, 1], 2),
+        ([4, 2], 20),
+        ([2, 4], 20),
+    ),
+)
+def test_pins_to_bitmask(pins, expected_mask):
+    assert gpio.pins_to_bitmask(pins) == expected_mask
+
+
+@pytest.mark.parametrize(
+    'mask,expected_pins',
+    (
+        (1, [0]),
+        (42, [1, 3, 5]),
+        (2, [1]),
+        (20, [2, 4]),
+    ),
+)
+def test_bitmask_to_pins(mask, expected_pins):
+    assert gpio.bitmask_to_pins(mask) == expected_pins
+
+
+def test_raise_if_not_supported(manager):
+    client = manager._comm.ClientConnection
+
+    with pytest.raises(gpio.PinNotSupportedError):
+        gpio.raise_if_pins_not_supported(client, pins=[-1], mode='read')
+
+    with pytest.raises(gpio.PinNotSupportedError):
+        gpio.raise_if_pins_not_supported(client, pins=[-1], mode='write')
+
+    with pytest.raises(gpio.PinNotSupportedError):
+        gpio.raise_if_pins_not_supported(client, pins=[9001], mode='read')
+
+    with pytest.raises(gpio.PinNotSupportedError):
+        gpio.raise_if_pins_not_supported(client, pins=[9001], mode='write')
+
+    read_pins = gpio.readable_pins(client)
+    write_pins = gpio.readable_pins(client)
+
+    gpio.raise_if_pins_not_supported(client, read_pins, mode='read')
+    gpio.raise_if_pins_not_supported(client, write_pins, mode='write')
+
+
+def test_readable_pins(manager):
+    pins = manager.gpio.readable_pins
+    assert pins
+    assert all(isinstance(val, int) for val in pins)
+
+
+def test_writable_pins(manager):
+    pins = manager.gpio.writable_pins
+    assert pins
+    assert all(isinstance(val, int) for val in pins)
+
+
+def test_read(manager):
+    pins = manager.gpio.readable_pins
+
+    level = manager.gpio.read(pins[0])
+    assert level in ('low', 'high')
+
+    levels = manager.gpio.read_many(pins)
+    assert len(levels) == len(pins)
+
+    with pytest.raises(gpio.PinNotSupportedError):
+        _ = manager.gpio.read(1234)
+
+
+def test_write(manager):
+    pins = manager.gpio.writable_pins
+
+    manager.gpio.write(pins[0], level='high')
+    manager.gpio.write(pins[0], level='low')
+    manager.gpio.write_many(pins)
+    manager.gpio.toggle_many(pins)
+
+    with pytest.raises(ValueError):
+        manager.gpio.write(pins[0], level='fail')

--- a/python/tests/test_gpio_async.py
+++ b/python/tests/test_gpio_async.py
@@ -19,6 +19,7 @@ async def manager():
         yield mgr
 
 
+@pytest.mark.instrument
 @pytest.mark.asyncio
 async def test_read_async(manager):
     pins = manager.gpio.readable_pins
@@ -33,6 +34,7 @@ async def test_read_async(manager):
         _ = await manager.gpio.read_async(1234)
 
 
+@pytest.mark.instrument
 @pytest.mark.asyncio
 async def test_write_async(manager):
     pins = manager.gpio.writable_pins

--- a/python/tests/test_gpio_async.py
+++ b/python/tests/test_gpio_async.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+import pytest_asyncio
+
+import pypalmsens as ps
+from pypalmsens._instruments import gpio
+
+logger = logging.getLogger(__name__)
+
+
+@pytest_asyncio.fixture(scope='module')
+async def manager():
+    instrument, *_ = await ps.discover_async()
+    async with await ps.connect_async(instrument) as mgr:
+        logger.warning('Connected to %s', mgr.instrument.id)
+        yield mgr
+
+
+@pytest.mark.asyncio
+async def test_read_async(manager):
+    pins = manager.gpio.readable_pins
+
+    level = await manager.gpio.read(pins[0])
+    assert level in ('low', 'high')
+
+    levels = await manager.gpio.read_many(pins)
+    assert len(levels) == len(pins)
+
+    with pytest.raises(gpio.PinNotSupportedError):
+        _ = await manager.gpio.read(1234)
+
+
+@pytest.mark.asyncio
+async def test_write_async(manager):
+    pins = manager.gpio.writable_pins
+
+    await manager.gpio.write(pins[0], level='high')
+    await manager.gpio.write(pins[0], level='low')
+    await manager.gpio.write_many(pins)
+    await manager.gpio.toggle_many(pins)
+
+    with pytest.raises(ValueError):
+        await manager.gpio.write(pins[0], level='fail')

--- a/python/tests/test_gpio_async.py
+++ b/python/tests/test_gpio_async.py
@@ -23,24 +23,24 @@ async def manager():
 async def test_read_async(manager):
     pins = manager.gpio.readable_pins
 
-    level = await manager.gpio.read(pins[0])
+    level = await manager.gpio.read_async(pins[0])
     assert level in ('low', 'high')
 
-    levels = await manager.gpio.read_many(pins)
+    levels = await manager.gpio.read_many_async(pins)
     assert len(levels) == len(pins)
 
     with pytest.raises(gpio.PinNotSupportedError):
-        _ = await manager.gpio.read(1234)
+        _ = await manager.gpio.read_async(1234)
 
 
 @pytest.mark.asyncio
 async def test_write_async(manager):
     pins = manager.gpio.writable_pins
 
-    await manager.gpio.write(pins[0], level='high')
-    await manager.gpio.write(pins[0], level='low')
-    await manager.gpio.write_many(pins)
-    await manager.gpio.toggle_many(pins)
+    await manager.gpio.write_async(pins[0], level='high')
+    await manager.gpio.write_async(pins[0], level='low')
+    await manager.gpio.write_many_async(pins)
+    await manager.gpio.toggle_many_async(pins)
 
     with pytest.raises(ValueError):
-        await manager.gpio.write(pins[0], level='fail')
+        await manager.gpio.write_async(pins[0], level='fail')

--- a/python/zensical.toml
+++ b/python/zensical.toml
@@ -17,6 +17,7 @@ nav = [
   "events.md",
   "filesystem.md",
   "comm_protocol.md",
+  "gpio.md",
   "circuit_fitting.md",
   "examples.md",
   { "Techniques" = [
@@ -70,6 +71,7 @@ nav = [
     "reference/instrument_async.md",
     "reference/filesystem.md",
     "reference/comm_protocol.md",
+    "reference/gpio.md",
     "reference/fitting.md",
     "reference/models.md",
     "reference/types.md",


### PR DESCRIPTION
This PR is a work in progress. So far I added the functions for basic io on the digital pins.

```python
>>> manager = ps.connect()

# reading
>>> manager.gpio.read(0)
'low'

# writing
>>> manager.gpio.write(0, 'high')
>>> manager.gpio.write(0, 'low')
>>> manager.gpio.write(0, 'toggle')
```

Closes #464 

### TODO

- [x] How to test this?
- [x] Add True/False, 1/0 as level options
- [x] Add gpio_write_pins, gpio_read_pins
- [x] Add tests
- [x] Add async
- [x] Add option to set multiple pins at once, e.g. `manager.gpio_write_pins([0,1,2], 'high')`
- [x] Add manager.gpio subclass
- [x] Fix type issues
- [x] Add section to docs

true = pin high, false = pin low

```csharp
connMS.SetDigitalOutput(0x0); //Set all pins low
connMS.SetDigitalOutput(3); //Set pins 0 and 1 high
connMS.SetDigitalOutput(0xFF); //Set all 8 pins high
```
