### PR TITLE
Rename class Gpio->GPIO

### DIFF
--- a/python/docs/zensical/gpio.md
+++ b/python/docs/zensical/gpio.md
@@ -1,16 +1,16 @@
 # Digital I/O (GPIO)
 
-The [pypalmsens.Gpio] and [pypalmsens.GpioAsync] classes provide access to the instrument’s digital input and output pins. Use it to read logic levels, drive outputs, or toggle control lines. The gpio api is exposed via the [InstrumentManager.gpio][pypalmsens.InstrumentManager.gpio] and [InstrumentManagerAsync.gpio][pypalmsens.InstrumentManagerAsync.gpio] attributes.
+The [pypalmsens.GPIO][] and [pypalmsens.GPIOAsync][] classes provide access to the instrument’s digital input and output pins. Use it to read logic levels, drive outputs, or toggle control lines. The gpio api is exposed via the [InstrumentManager.gpio][pypalmsens.InstrumentManager.gpio] and [InstrumentManagerAsync.gpio][pypalmsens.InstrumentManagerAsync.gpio] attributes.
 
-- **Direction auto-configuration:** For MethodSCRIPT devices, the library automatically configures pin direction when you call [read][pypalmsens.Gpio.read] (input) or [write][pypalmsens.Gpio.write] / [toggle][pypalmsens.Gpio.toggle] (output) operations. If you need explicit low-level control, use [MethodSCRIPT](https://dev.palmsens.com/methodscript/latest/methodscript/methodscript_main.html), either directly or via [pypalmsens.CommProtocol][].
+- **Direction auto-configuration:** For MethodSCRIPT devices, the library automatically configures pin direction when you call [read][pypalmsens.GPIO.read] (input) or [write][pypalmsens.GPIO.write] / [toggle][pypalmsens.GPIO.toggle] (output) operations. If you need explicit low-level control, use [MethodSCRIPT](https://dev.palmsens.com/methodscript/latest/methodscript/methodscript_main.html), either directly or via [pypalmsens.CommProtocol][].
 
-- **Atomicity:** [write_many][pypalmsens.Gpio.write_many] and [toggle_many][pypalmsens.Gpio.toggle_many] are sent as a single instruction. How the chip process the instruction may differ from device to device. If your use case requires strict timing (e.g., simultaneous pin changes), prefer the batch methods over multiple single-pin calls.
+- **Atomicity:** [write_many][pypalmsens.GPIO.write_many] and [toggle_many][pypalmsens.GPIO.toggle_many] are sent as a single instruction. How the chip process the instruction may differ from device to device. If your use case requires strict timing (e.g., simultaneous pin changes), prefer the batch methods over multiple single-pin calls.
 
 ## Pin numbering
 
 The integers you pass to read / write are the internal pin numbers exposed by the firmware API, not necessarily the labels on the hardware (e.g., d0, d3). The mapping is consistent for a given instrument model, so code that works on one unit will work on an identical unit. Consult the instrument manual for the physical mapping.
 
-Pin numbers and the mix of readable vs. writable pins depend on the specific instrument model. Consult [writable_pins][pypalmsens.Gpio.writable_pins] and [readable_pins][pypalmsens.Gpio.readable_pins] at runtime if you work with multiple device types.
+Pin numbers and the mix of readable vs. writable pins depend on the specific instrument model. Consult [writable_pins][pypalmsens.GPIO.writable_pins] and [readable_pins][pypalmsens.GPIO.readable_pins] at runtime if you work with multiple device types.
 
 ## Available pins
 

--- a/python/docs/zensical/reference/gpio.md
+++ b/python/docs/zensical/reference/gpio.md
@@ -1,7 +1,7 @@
 # GPIO
 
 This class provides high-level access to the instrument's digital pins.
-The API is defined in [pypalmsens.Gpio][], and [pypalmsens.GpioAsync][] for asynchronous workflows.
+The API is defined in [pypalmsens.GPIO][], and [pypalmsens.GPIOAsync][] for asynchronous workflows.
 
 The intended usage of these classes is via the [InstrumentManager.gpio][pypalmsens.InstrumentManager.gpio] and [InstrumentManager.gpio][pypalmsens.InstrumentManager.gpio] attributes.
 
@@ -23,8 +23,8 @@ For more information how to use these classes, see [the documentation here](../g
 
 **Classes:**
 
-- [`pypalmsens.Gpio`][pypalmsens.Gpio]
-- [`pypalmsens.GpioAsync`][pypalmsens.GpioAsync]
+- [`pypalmsens.GPIO`][pypalmsens.GPIO]
+- [`pypalmsens.GPIOAsync`][pypalmsens.GPIOAsync]
 
-::: pypalmsens.Gpio
-::: pypalmsens.GpioAsync
+::: pypalmsens.GPIO
+::: pypalmsens.GPIOAsync

--- a/python/docs/zensical/reference/index.md
+++ b/python/docs/zensical/reference/index.md
@@ -2,7 +2,7 @@
 
 PyPalmSens is a Python library that lets you control your PalmSens device using Python.
 
-[pypalmsens][]
+[pypalmsens](./index.md)
 
 :   The most-used functions and classes are available from the root module.
 

--- a/python/src/pypalmsens/__init__.py
+++ b/python/src/pypalmsens/__init__.py
@@ -30,8 +30,8 @@ from ._instruments.comm_protocol import CommProtocol
 from ._instruments.comm_protocol_async import CommProtocolAsync
 from ._instruments.filesystem import DeviceFileSystem, DevicePath
 from ._instruments.filesystem_async import DeviceFileSystemAsync
-from ._instruments.gpio import Gpio
-from ._instruments.gpio_async import GpioAsync
+from ._instruments.gpio import GPIO
+from ._instruments.gpio_async import GPIOAsync
 from ._instruments.instrument import Instrument, discover, discover_async
 from ._instruments.instrument_manager import (
     InstrumentManager,
@@ -82,6 +82,7 @@ from ._methods.techniques import (
 from ._stream import load_stream_file
 
 __all__ = [
+    'GPIO',
     'ACVoltammetry',
     'ChronoAmperometry',
     'ChronoCoulometry',
@@ -98,9 +99,8 @@ __all__ = [
     'FastCyclicVoltammetry',
     'FastGalvanostaticImpedanceSpectroscopy',
     'FastImpedanceSpectroscopy',
+    'GPIOAsync',
     'GalvanostaticImpedanceSpectroscopy',
-    'Gpio',
-    'GpioAsync',
     'Instrument',
     'InstrumentManager',
     'InstrumentManagerAsync',

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -84,7 +84,7 @@ def raise_if_pins_not_supported(
 
 
 @final
-class Gpio:
+class GPIO:
     """Digital general-purpose input/output (GPIO) interface.
 
     This class provides high-level access to the instrument's digital

--- a/python/src/pypalmsens/_instruments/gpio_async.py
+++ b/python/src/pypalmsens/_instruments/gpio_async.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 @final
-class GpioAsync:
+class GPIOAsync:
     """Digital general-purpose input/output (GPIO) interface.
 
     This class provides high-level access to the instrument's digital

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -30,7 +30,7 @@ from .callback import Callback, CallbackEIS, Status
 from .capabilities_mixin import CapabilitiesMixin
 from .comm_protocol import CommProtocol
 from .events_mixin import EventsMixin
-from .gpio import Gpio
+from .gpio import GPIO
 from .instrument import Instrument, discover
 from .measurement_manager_async import MeasurementManagerAsync
 from .shared import firmware_warning
@@ -127,7 +127,7 @@ class InstrumentManager(CapabilitiesMixin, EventsMixin):
         self.instrument: Instrument = instrument
         """Instrument being managed by this class."""
 
-        self.gpio: Gpio = Gpio(self)
+        self.gpio: GPIO = GPIO(self)
         """High-level GPIO interface."""
 
         self._comm: CommManager

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -31,7 +31,7 @@ from .callback import Callback, CallbackEIS, CallbackStatus, Status
 from .capabilities_mixin import CapabilitiesMixin
 from .comm_protocol_async import CommProtocolAsync
 from .events_mixin import EventsMixin
-from .gpio_async import GpioAsync
+from .gpio_async import GPIOAsync
 from .instrument import Instrument, discover_async
 from .measurement_manager_async import MeasurementManagerAsync
 from .shared import create_future, firmware_warning
@@ -125,7 +125,7 @@ class InstrumentManagerAsync(CapabilitiesMixin, EventsMixin):
         self.instrument: Instrument = instrument
         """Instrument being managed by this class."""
 
-        self.gpio: GpioAsync = GpioAsync(self)
+        self.gpio: GPIOAsync = GPIOAsync(self)
         """High-level GPIO interface."""
 
         self._comm: CommManager


### PR DESCRIPTION
PEP8 recommends all caps for acronyms in classnames: 

> When using acronyms in CapWords, capitalize all the letters of the acronym. Thus HTTPServerError is better than HttpServerError.

https://peps.python.org/pep-0008/#descriptive-naming-styles

This PR also fixes a few broken api links.

Fix-up for #469 