### PR TITLE
Drop support for Python 3.10

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -30,7 +30,7 @@ jobs:
           # 'macos-latest',
           'ubuntu-latest',
         ]
-        python-version: ['3.10', '3.14']
+        python-version: ['3.11', '3.14']
     defaults:
       run:
         working-directory: ./python

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '9'
+          dotnet-version: '10'
 
       - uses: actions/cache@v5
         id: cache-virtualenv

--- a/python/docs/zensical/installation.md
+++ b/python/docs/zensical/installation.md
@@ -14,7 +14,7 @@ pip install pypalmsens
 
 ## Windows
 
-*   Install [Python](https://python.org) version 3.10 or newer
+*   Install [Python](https://python.org) version 3.11 or newer
 *   Install [.NET Runtime 10.0](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) or newer
 *   Install device drivers (see the [Compatibility table](#compatibility)):
     * If you installed PSTrace or Multitrace, drivers are already installed
@@ -22,7 +22,7 @@ pip install pypalmsens
 
 ## Linux and macOS {#req-linux}
 
-*   Install [Python](https://python.org) version 3.10 or newer
+*   Install [Python](https://python.org) version 3.11 or newer
 *   Install [.NET Runtime 10.0](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) or newer. You can typically find the required runtime (e.g., `dotnet-runtime-10.0`) in your [package manager](https://learn.microsoft.com/en-us/dotnet/core/install/linux).
     *   [Installation guides for Ubuntu](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu-install)
     *   [Installation guides for Debian](https://learn.microsoft.com/en-us/dotnet/core/install/linux-debian)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -8,7 +8,7 @@ name = "PyPalmSens"
 version = "1.11.0"
 description = "Python SDK for PalmSens instruments"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
 	{name = "Palmsens BV", email = "info@palmsens.com"},
 ]
@@ -27,7 +27,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/python/src/pypalmsens/_instruments/filesystem.py
+++ b/python/src/pypalmsens/_instruments/filesystem.py
@@ -18,7 +18,7 @@ class FileSystemException(OSError):
 
 
 if sys.version_info < (3, 12):
-    # In 3.10 and 3.11, PurePath does not support subclassing
+    # In 3.11, PurePath does not support subclassing
     # See: https://docs.python.org/3.12/whatsnew/3.12.html#pathlib
 
     from pathlib import PurePosixPath


### PR DESCRIPTION
This PR drops support for Python 3.10, which reaches end of life on 31 Oct 2026.

