### PR TITLE
Improve release tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ example.pssession
 .bundle
 
 review.md
+
+# Release tooling
+changelog-python.md

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -112,7 +112,9 @@ def update_python(new_tag: str, new_version: str) -> str:
         anchor='pypalmsens-' + new_version.replace('.', ''),
     )
 
-    with open('changelog-python.md', 'w') as f:
+    notes_path = ROOT / 'changelog-python.md'
+
+    with open(notes_path, 'w') as f:
         f.write(gh_releases)
 
     return gh_releases

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -14,7 +14,7 @@ def get_latest_tag(component: str = 'python'):
     p = sp.run(cmd, capture_output=True, check=True)
     tags = p.stdout.decode().splitlines()
     for line in tags:
-        if line.startswith(component):
+        if line.startswith(f'{component}-'):
             latest = line
             break
     else:
@@ -23,15 +23,17 @@ def get_latest_tag(component: str = 'python'):
 
 
 def get_changes_since_tag(tag: str):
-    cmd = f'git log {tag}..HEAD --reverse --oneline'.split()
+    cmd = ['git', 'log', f'{tag}..HEAD', '--reverse', '--oneline']
     p = sp.run(cmd, capture_output=True, check=True)
     lines = p.stdout.decode().splitlines()
     lines = (line.split(maxsplit=1)[1] for line in lines)
 
     out = []
+    skipped = []
 
     for line in lines:
         if '(#' not in line and not line.endswith(')'):
+            skipped.append(line)
             continue
 
         if line.startswith('('):
@@ -45,11 +47,18 @@ def get_changes_since_tag(tag: str):
         )
         out.append(f'- {line}')
 
+    if skipped:
+        print('Warning: commits not included in changelog:')
+        for line in skipped:
+            print(f'  - {line}')
+
     return '\n'.join(out)
 
 
-def update_python(new_tag: str, new_version: str) -> str:
-    previous_tag = get_latest_tag()
+def update_python(new_tag: str, new_version: str, previous_tag: str | None = None) -> str:
+    if previous_tag is None:
+        previous_tag = get_latest_tag()
+
     changelog = get_changes_since_tag(previous_tag)
 
     time = datetime.datetime.now(tz=datetime.UTC)
@@ -124,10 +133,11 @@ if __name__ == '__main__':
     component = 'python'
     args = sys.argv[1:]
 
-    assert len(args) == 2
+    if len(args) != 2:
+        sys.exit(f'usage: {sys.argv[0]} <previous_version> <new_version>')
 
     previous_version, new_version = args
     previous_tag = f'{component}-{previous_version}'
     new_tag = f'{component}-{new_version}'
 
-    update_python(new_tag, new_version)
+    update_python(new_tag, new_version, previous_tag)

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -4,14 +4,17 @@ import argparse
 import json
 import shutil
 import subprocess as sp
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-for exe in ('gh', 'bump-my-version'):
-    assert shutil.which(exe)
-
 ROOT = Path(__file__).parents[1]
+
+
+for exe in ('gh', 'bump-my-version'):
+    if not shutil.which(exe):
+        sys.exit(f'{exe} is not installed or not on PATH')
 
 PR_BODY = """\
 This PR prepares for a new release of the {sdk.name} SDK.
@@ -63,12 +66,15 @@ def commit_file(path: str | Path, message: str):
 
 def update_releases(sdk: SDK, commit: bool = False):
     releases_path = Path(ROOT, 'docs', 'sdk', 'modules', 'ROOT', 'pages', 'releases.adoc')
-    assert releases_path.exists()
+
+    if not releases_path.exists():
+        sys.exit(f'{releases_path} does not exist')
+
     lines = releases_path.read_text().splitlines()
 
     index = lines.index('// latest')
 
-    if sdk.tag in lines[index + 1]:
+    if any(sdk.tag in line for line in lines):
         print('Tag already exists, skipping')
     else:
         new_line = (
@@ -106,7 +112,7 @@ def assert_clean_worktree():
         raise RuntimeError(f'Git working tree is not clean:\n\n{status}')
 
 
-def prepare_release_branch(base_branch: str, release_branch: str) -> str:
+def prepare_release_branch(base_branch: str, release_branch: str):
     assert_clean_worktree()
 
     sp.check_call(['git', 'fetch', 'origin'])
@@ -117,8 +123,6 @@ def prepare_release_branch(base_branch: str, release_branch: str) -> str:
 
     print(f'Created branch {release_branch}')
 
-    return release_branch
-
 
 def push_branch_and_create_pr(sdk: SDK, *, body: str, base_branch: str, release_branch: str):
     sp.run(
@@ -127,7 +131,7 @@ def push_branch_and_create_pr(sdk: SDK, *, body: str, base_branch: str, release_
     )
     print(f'Pushed {release_branch}')
 
-    body = PR_BODY.format(version=sdk.version, body=body, sdk=sdk, tag=sdk.tag)
+    body = PR_BODY.format(body=body, sdk=sdk)
     print(body)
 
     p = sp.run(
@@ -167,6 +171,14 @@ if __name__ == '__main__':
     else:
         sdk = SDK(options.sdk, options.version)
 
+    if not sdk.version:
+        sys.exit('Specify --version or --bump.')
+
+    current_version = sdk.old_version()
+    if current_version == sdk.version:
+        sys.exit(f'{sdk.name} is already at version {sdk.version}; nothing to do.')
+
+    print(f'Current version: {current_version}')
     print(f'New version: {sdk.tag=}')
 
     base_branch = 'main'

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import argparse
-import os
+import json
 import shutil
 import subprocess as sp
-from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -36,16 +35,14 @@ class SDK:
         """Get current version."""
         cmd = ['bump-my-version', 'show', 'current_version']
 
-        with self.chdir():
-            p = sp.run(cmd, capture_output=True, check=True)
+        p = sp.run(cmd, capture_output=True, check=True, cwd=self.workdir)
 
         return p.stdout.decode().strip()
 
     def bump(self, component: Literal['major', 'minor', 'patch']) -> SDK:
         cmd = ['bump-my-version', 'show', '--increment', component, 'new_version']
 
-        with self.chdir():
-            p = sp.run(cmd, capture_output=True, check=True)
+        p = sp.run(cmd, capture_output=True, check=True, cwd=self.workdir)
 
         new_version = p.stdout.decode().strip()
         return SDK(self.name, new_version)
@@ -57,15 +54,6 @@ class SDK:
     @property
     def workdir(self) -> Path:
         return ROOT / self.name
-
-    @contextmanager
-    def chdir(self):
-        prev_cwd = Path.cwd().resolve()
-        try:
-            os.chdir(self.workdir)
-            yield
-        finally:
-            os.chdir(prev_cwd)
 
 
 def commit_file(path: str | Path, message: str):
@@ -95,29 +83,37 @@ def update_releases(sdk: SDK, commit: bool = False):
 
 
 def bump_version_to(sdk: SDK):
-    with sdk.chdir():
-        sp.check_call(
-            [
-                'bump-my-version',
-                'bump',
-                '--new-version',
-                sdk.version,
-                'patch',
-                '--commit',
-                '--allow-dirty',
-            ]
-        )
+    sp.check_call(
+        [
+            'bump-my-version',
+            'bump',
+            '--new-version',
+            sdk.version,
+            'patch',
+            '--commit',
+            '--allow-dirty',
+        ],
+        cwd=sdk.workdir,
+    )
 
     print(f'Set {sdk.name} version to {sdk.version}')
 
 
+def assert_clean_worktree():
+    p = sp.run(['git', 'status', '--porcelain'], capture_output=True, check=True)
+    status = p.stdout.decode().strip()
+    if status:
+        raise RuntimeError(f'Git working tree is not clean:\n\n{status}')
+
+
 def prepare_release_branch(base_branch: str, release_branch: str) -> str:
+    assert_clean_worktree()
+
+    sp.check_call(['git', 'fetch', 'origin'])
+
     sp.check_call(['git', 'checkout', f'origin/{base_branch}'])
 
-    sp.run(
-        ['git', 'checkout', '-b', release_branch, f'origin/{base_branch}'],
-        check=True,
-    )
+    sp.check_call(['git', 'checkout', '-b', release_branch, f'origin/{base_branch}'])
 
     print(f'Created branch {release_branch}')
 
@@ -134,7 +130,7 @@ def push_branch_and_create_pr(sdk: SDK, *, body: str, base_branch: str, release_
     body = PR_BODY.format(version=sdk.version, body=body, sdk=sdk, tag=sdk.tag)
     print(body)
 
-    sp.run(
+    p = sp.run(
         [
             'gh',
             'pr',
@@ -144,14 +140,23 @@ def push_branch_and_create_pr(sdk: SDK, *, body: str, base_branch: str, release_
             f'--title=Release {sdk.tag}',
             f'--body={body}',
             '--draft',
+            '--json',
+            'url',
         ],
+        capture_output=True,
         check=True,
     )
+    pr_url = json.loads(p.stdout)['url']
+    print(f'PR created: {pr_url}')
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('sdk', type=str)
+    parser.add_argument(
+        'sdk',
+        type=str,
+        choices=['python', 'matlab', 'maui', 'wpf', 'labview', 'winforms'],
+    )
     parser.add_argument('--version', type=str, help='Set version.')
     parser.add_argument('--bump', type=str, help='Major/minor/patch, overrides version.')
     options = parser.parse_args()
@@ -185,7 +190,7 @@ if __name__ == '__main__':
 
     if sdk.name == 'python':
         title = 'PyPalmSens'
-        notesopt = '--notes-file changelog-python.md'
+        notesopt = f'--notes-file {ROOT / "changelog-python.md"}'
     else:
         title = sdk.name
         notesopt = '--generate-notes'


### PR DESCRIPTION
This PR cleans up the release tooling. `prepare_release.py` and `changelog.py` will now validate their inputs and fail early. The changelog also warns about any commits that were not missed. The  PR URL is printed to the terminal.