### PR TITLE
Add method for baseline correction

### DIFF
--- a/python/docs/zensical/data.md
+++ b/python/docs/zensical/data.md
@@ -108,7 +108,9 @@ The resulting plot looks like this:
 
 ![Image of DPV plot](assets/dpv_figure_1.png){ width="80%" }
 
-The measurement stores a single peak. You can retrieve it using:
+### Peak-finding
+
+The measurement above stores a single peak. You can retrieve it using:
 
 ```pycon
 >>> peaks = curve.peaks
@@ -133,6 +135,8 @@ Alternatively, for Cyclic Voltammetry (CV) and Linear Sweep Voltammetry (LSV), y
     The peak finder may not always find peaks on the first attempt depending on your data. You may need to tune parameters for better results.
     See [pypalmsens.data.Curve.find_peaks][] for more information.
 
+### Smoothing
+
 You can also filter data using [pypalmsens.data.Curve.smooth][]. Note that this method updates the curve in-place:
 
 ```pycon
@@ -147,7 +151,42 @@ Or, you can use a [Savitsky-Golay filter](https://en.wikipedia.org/wiki/Savitzky
 
 ```
 
-Curve data are devived from the underlying [Dataset](#dataset), where variable data are stored in [DataArray](#dataarray)'s.
+### Baseline correction
+
+You can perform baseline correction using [pypalmsens.data.Curve.remove_baseline][].
+
+This applies a moving-average baseline correction and returns the corrected curve and the calculated baseline.
+This function is equivalent to the 'Moving Average Baseline' function in PSTrace.
+
+The function returns a `BaselineResult` named tuple, so you can unpack the two values directly:
+
+```pycon
+>>> corrected, baseline = curve.remove_baseline(max_sweeps=500, window_size=2)
+
+>>> corrected
+Curve(title=Curve (corrected), n_points=219)
+
+>>> baseline
+Curve(title=Curve (baseline), n_points=219)
+
+```
+
+Or access them by name:
+
+```pycon
+>>> result = curve.remove_baseline(max_sweeps=500, window_size=2)
+
+>>> result.corrected
+Curve(title=Curve (corrected), n_points=219)
+
+>>> result.baseline
+Curve(title=Curve (baseline), n_points=219)
+
+```
+
+### Data access
+
+Curve data are derived from the underlying [Dataset](#dataset), where variable data are stored in [DataArray](#dataarray)'s.
 To access the raw x and y data for custom plotting or analysis, use `curve.x_array` and `curve.y_array`.
 Both return [DataArray](#dataarray) objects that can be converted to standard Python floats or numpy arrays:
 

--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -177,6 +177,7 @@ class Curve:
         -------
         BaselineResult
             A named tuple containing:
+
             - `corrected` : The baseline-corrected curve.
             - `baseline` : The calculated baseline curve that was subtracted.
 
@@ -187,7 +188,7 @@ class Curve:
 
         Attribute access:
         >>> result = curve.remove_baseline(max_sweeps=500, window_size=2)
-        >>> plot(result.corrected, result.baseline)
+        >>> result.corrected, result.baseline
         """
 
         assert mode == 'moving-average'

--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, final
+from typing import TYPE_CHECKING, Literal, NamedTuple, final
 
+import PalmSens
 import PalmSens.Analysis as PSAnalysis
 import System
 from PalmSens.Plottables import Curve as PSCurve
@@ -149,6 +150,65 @@ class Curve:
 
         return self.peaks
 
+    def remove_baseline(
+        self,
+        max_sweeps: int = 1001,
+        window_size: int = 2,
+        mode: Literal['moving-average'] = 'moving-average',
+    ) -> tuple[Curve, Curve]:
+        """Perform the moving average baseline correction on a curve.
+
+        This method calculates and applies a baseline correction using a specified
+        moving average window size and a maximum number of sweeps allowed.
+
+        Parameters
+        ----------
+        max_sweeps : int, optional
+            The maximum number of sweeps allowed during the baseline correction process.
+            Defaults to 1001.
+        window_size : int, optional
+            The size of the moving average window used for calculating the baseline.
+            Defaults to 2.
+        mode : str, optional
+            The method used for baseline correction (e.g., 'moving-average').
+            Defaults to 'moving-average'.
+
+        Returns
+        -------
+        BaselineResult
+            A named tuple containing:
+            - `corrected` : The baseline-corrected curve.
+            - `baseline` : The calculated baseline curve that was subtracted.
+
+        Examples
+        --------
+        Unpacking as a tuple:
+        >>> corrected, baseline = curve.remove_baseline(max_sweeps=500, window_size=2)
+
+        Attribute access:
+        >>> result = curve.remove_baseline(max_sweeps=500, window_size=2)
+        >>> plot(result.corrected, result.baseline)
+        """
+
+        assert mode == 'moving-average'
+
+        class BaselineResult(NamedTuple):
+            corrected: Curve
+            baseline: Curve
+
+        _corrected = PalmSens.Analysis.BaselineCorrection.GetMovingAverageBaselineCorrected(
+            self._pscurve, nWindowSize=window_size, maxNSweeps=max_sweeps, baseline=False
+        )
+        _corrected.Title = self.title + ' (corrected)'
+        _baseline = PalmSens.Analysis.BaselineCorrection.GetMovingAverageBaselineCorrected(
+            self._pscurve, nWindowSize=window_size, maxNSweeps=max_sweeps, baseline=True
+        )
+        _baseline.Title = self.title + ' (baseline)'
+
+        return BaselineResult(
+            corrected=Curve(pscurve=_corrected), baseline=Curve(pscurve=_baseline)
+        )
+
     @property
     def max_x(self) -> float:
         """Maximum X value found in this curve."""
@@ -187,20 +247,6 @@ class Curve:
     def ocp_value(self) -> float:
         """OCP value for curve."""
         return self._pscurve.OCPValue
-
-    @property
-    def reference_electrode_name(self) -> None | str:
-        """The name of the reference electrode. Return None if not set."""
-        if ret := self._pscurve.ReferenceElectrodeName:
-            return str(ret)
-        return None
-
-    @property
-    def reference_electrode_potential(self) -> None | str:
-        """The reference electrode potential offset. Return None if not set."""
-        if ret := self._pscurve.ReferenceElectrodePotential:
-            return str(ret)
-        return None
 
     @property
     def x_unit(self) -> str:

--- a/python/tests/test_curve.py
+++ b/python/tests/test_curve.py
@@ -114,3 +114,18 @@ def test_curve_copy(curve_dpv):
     assert curve_dpv._pscurve is not new_curve._pscurve
     assert curve_dpv._pscurve.XAxisDataArray is not new_curve._pscurve.XAxisDataArray
     assert curve_dpv._pscurve.YAxisDataArray is not new_curve._pscurve.YAxisDataArray
+
+
+def test_curve_remove_baseline(curve_dpv):
+    corrected, baseline = curve_dpv.remove_baseline(max_sweeps=1001, window_size=2)
+
+    assert baseline.title.endswith('(baseline)')
+    assert corrected.title.endswith('(corrected)')
+
+    assert list(corrected.x_array) == list(curve_dpv.x_array)
+    assert list(baseline.x_array) == list(curve_dpv.x_array)
+
+    assert list(corrected.y_array) != list(curve_dpv.y_array)
+    assert list(baseline.y_array) != list(curve_dpv.y_array)
+
+    assert sum(curve_dpv.y_array) > sum(corrected.y_array) > sum(baseline.y_array)

--- a/python/tests/test_curve.py
+++ b/python/tests/test_curve.py
@@ -88,8 +88,6 @@ def test_curve_properties(curve_dpv):
     assert curve_dpv.mux_channel == -1
 
     assert isnan(curve_dpv.ocp_value)
-    assert not curve_dpv.reference_electrode_name
-    assert not curve_dpv.reference_electrode_potential
     assert curve_dpv.x_unit == 'V'
     assert curve_dpv.x_label == 'Potential'
     assert curve_dpv.y_unit == 'µA'


### PR DESCRIPTION
This PR adds a method for moving baseline correction to PyPalmSens.

## Baseline correction

This method calculates and applies a baseline correction using a specified
moving average window size and a maximum number of sweeps allowed.

The function returns a named tuple, so you can unpack the two values directly as a tuple:

```pycon
>>> corrected, baseline = curve.remove_baseline(max_sweeps=500, window_size=2)
```

Or access them by name:

```pycon
>>> result = curve.remove_baseline(max_sweeps=500, window_size=2)
>>> result.corrected, result.baseline
```