### PR TITLE
Add curve/array arithmetic operators (`+`, `-`, `*`)

### DIFF
--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, final
+from typing import TYPE_CHECKING, Literal, Self, final
 
 import PalmSens.Analysis as PSAnalysis
 import System
@@ -51,34 +51,34 @@ class Curve:
     def __init__(self, *, pscurve: PSCurve):
         self._pscurve = pscurve
 
-    def __add__(self, other: object) -> Curve:
+    def __add__(self, other: object) -> Self:
         if not isinstance(other, Curve):
             return NotImplemented
 
         operator = PSMath.enumOperator.Add
         new_curve = PSMath.AddSubtractCurves(self._pscurve, other._pscurve, operator)
 
-        return Curve(pscurve=new_curve)
+        return type(self)(pscurve=new_curve)
 
     __radd__ = __add__
 
-    def __sub__(self, other: object) -> Curve:
+    def __sub__(self, other: object) -> Self:
         if not isinstance(other, Curve):
             return NotImplemented
 
         operator = PSMath.enumOperator.Subtract
         new_curve = PSMath.AddSubtractCurves(self._pscurve, other._pscurve, operator)
 
-        return Curve(pscurve=new_curve)
+        return type(self)(pscurve=new_curve)
 
-    def __rsub__(self, other: object) -> Curve:
+    def __rsub__(self, other: object) -> Self:
         if not isinstance(other, Curve):
             return NotImplemented
 
         operator = PSMath.enumOperator.Subtract
         new_curve = PSMath.AddSubtractCurves(other._pscurve, self._pscurve, operator)
 
-        return Curve(pscurve=new_curve)
+        return type(self)(pscurve=new_curve)
 
     @override
     def __repr__(self):

--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Literal, final
 
 import PalmSens.Analysis as PSAnalysis
 import System
+from PalmSens.Calculations import MathFunctions as PSMath
 from PalmSens.Plottables import Curve as PSCurve
 from pydantic import TypeAdapter
 from pydantic.dataclasses import dataclass as pydantic_dataclass
@@ -40,10 +41,44 @@ class Curve:
     ----------
     pscurve
         Reference to .NET curve object.
+
+    Notes
+    -----
+    Supports arithmetic between curves. ``curve_a + curve_b`` and
+    ``curve_a - curve_b`` return new curves.
     """
 
     def __init__(self, *, pscurve: PSCurve):
         self._pscurve = pscurve
+
+    def __add__(self, other: object) -> Curve:
+        if not isinstance(other, Curve):
+            return NotImplemented
+
+        operator = PSMath.enumOperator.Add
+        new_curve = PSMath.AddSubtractCurves(self._pscurve, other._pscurve, operator)
+
+        return Curve(pscurve=new_curve)
+
+    __radd__ = __add__
+
+    def __sub__(self, other: object) -> Curve:
+        if not isinstance(other, Curve):
+            return NotImplemented
+
+        operator = PSMath.enumOperator.Subtract
+        new_curve = PSMath.AddSubtractCurves(self._pscurve, other._pscurve, operator)
+
+        return Curve(pscurve=new_curve)
+
+    def __rsub__(self, other: object) -> Curve:
+        if not isinstance(other, Curve):
+            return NotImplemented
+
+        operator = PSMath.enumOperator.Subtract
+        new_curve = PSMath.AddSubtractCurves(other._pscurve, self._pscurve, operator)
+
+        return Curve(pscurve=new_curve)
 
     @override
     def __repr__(self):

--- a/python/src/pypalmsens/_data/data_array.py
+++ b/python/src/pypalmsens/_data/data_array.py
@@ -4,9 +4,9 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Self, overload
 
 import numpy as np
-from typing_extensions import override
-
 from PalmSens.Calculations import MathFunctions as PSMath
+from PalmSens.Data import DataArray as PSDataArray
+from typing_extensions import override
 
 from .._converters import cr_enum_to_string, pr_enum_to_string
 from .._types import (
@@ -20,7 +20,6 @@ from .types import AllowedArrayTypes, array_enum_to_str
 
 if TYPE_CHECKING:
     import pandas as pd
-    from PalmSens.Data import DataArray as PSDataArray
 
 
 def implementation(interface):
@@ -80,7 +79,7 @@ class DataArray(Sequence[float]):
             return NotImplemented
 
         operator = PSMath.enumOperator.Add
-        new_array = PSMath.AddSubtractCurves(self._psarray, other._psarray, operator)
+        new_array = PSMath.AddSubtractDataArrays(self._psarray, other._psarray, operator)
 
         return type(self)(psarray=new_array)
 
@@ -92,7 +91,7 @@ class DataArray(Sequence[float]):
             return NotImplemented
 
         operator = PSMath.enumOperator.Subtract
-        new_array = PSMath.AddSubtractCurves(self._psarray, other._psarray, operator)
+        new_array = PSMath.AddSubtractDataArrays(self._psarray, other._psarray, operator)
 
         return type(self)(psarray=new_array)
 
@@ -101,7 +100,7 @@ class DataArray(Sequence[float]):
             return NotImplemented
 
         operator = PSMath.enumOperator.Subtract
-        new_array = PSMath.AddSubtractCurves(other._psarray, self._psarray, operator)
+        new_array = PSMath.AddSubtractDataArrays(other._psarray, self._psarray, operator)
 
         return type(self)(psarray=new_array)
 
@@ -109,7 +108,13 @@ class DataArray(Sequence[float]):
         if not isinstance(value, (int, float)):
             return NotImplemented
 
-        new_array = PSMath.MultiplyDataArray(self._psarray, value)
+        new_values = PSMath.MultiplyDataArray(self._psarray.GetValues(), value)
+
+        new_array = PSDataArray(
+            self._psarray.Description, self._psarray.Unit, self._psarray.ArrayType
+        )
+        new_array.AddRange(new_values)
+
         return type(self)(psarray=new_array)
 
     def __rmul__(self, value: object) -> Self:

--- a/python/src/pypalmsens/_data/data_array.py
+++ b/python/src/pypalmsens/_data/data_array.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, Self, overload
 
 import numpy as np
 from typing_extensions import override
+
+from PalmSens.Calculations import MathFunctions as PSMath
 
 from .._converters import cr_enum_to_string, pr_enum_to_string
 from .._types import (
@@ -36,6 +38,12 @@ class DataArray(Sequence[float]):
     ----------
     psarray
         Reference to .NET DataArray object.
+
+    Notes
+    -----
+    Supports arithmetic between arrays of the same type.
+    ``array_a + array_b``, ``array_a - array_b`` and
+    ``array_a * factor`` return new arrays.
     """
 
     def __init__(self, *, psarray: PSDataArray):
@@ -67,6 +75,45 @@ class DataArray(Sequence[float]):
     def __len__(self) -> int:
         return len(self._psarray)
 
+    def __add__(self, other: object) -> Self:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+
+        operator = PSMath.enumOperator.Add
+        new_array = PSMath.AddSubtractCurves(self._psarray, other._psarray, operator)
+
+        return type(self)(psarray=new_array)
+
+    def __radd__(self, other: object) -> Self:
+        return self.__add__(other)
+
+    def __sub__(self, other: object) -> Self:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+
+        operator = PSMath.enumOperator.Subtract
+        new_array = PSMath.AddSubtractCurves(self._psarray, other._psarray, operator)
+
+        return type(self)(psarray=new_array)
+
+    def __rsub__(self, other: object) -> Self:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+
+        operator = PSMath.enumOperator.Subtract
+        new_array = PSMath.AddSubtractCurves(other._psarray, self._psarray, operator)
+
+        return type(self)(psarray=new_array)
+
+    def __mul__(self, value: object) -> Self:
+        if not isinstance(value, (int, float)):
+            return NotImplemented
+
+        new_array = PSMath.MultiplyDataArray(self._psarray, value)
+        return type(self)(psarray=new_array)
+
+    def __rmul__(self, value: object) -> Self:
+        return self.__mul__(value)
     def copy(self) -> DataArray:
         """Return a copy of the array."""
         return DataArray(psarray=self._psarray.Clone())

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -85,6 +85,81 @@ def test_current_array(measurement_cv_1scan):
     assert len(d) == 5
 
 
+def test_array_add(array):
+    a = array.copy()
+    b = a + a
+
+    result = a + b
+    assert len(result) == len(a)
+
+    a_np = a.to_numpy()
+    expected = a_np + b.to_numpy()
+    np.testing.assert_allclose(result.to_numpy(), expected)
+
+
+def test_array_add_commutative(array):
+    a = array.copy()
+    b = a + a
+
+    np.testing.assert_allclose(
+        (a + b).to_numpy(),
+        (b + a).to_numpy(),
+    )
+
+
+def test_array_sub(array):
+    a = array.copy()
+    b = a + a
+
+    result = b - a
+    assert len(result) == len(a)
+    np.testing.assert_allclose(result.to_numpy(), a.to_numpy())
+
+    reverse = a - b
+    np.testing.assert_allclose(reverse.to_numpy(), -a.to_numpy())
+    np.testing.assert_allclose(reverse.to_numpy(), -result.to_numpy())
+
+    zero = a-a
+    np.testing.assert_allclose(zero.to_numpy(), 0)
+
+
+def test_array_rsub_direction(array):
+    a = array.copy()
+    b = a + a
+
+    result = type(array).__rsub__(a, b)
+
+    np.testing.assert_allclose(result.to_numpy(), (b - a).to_numpy())
+
+
+def test_array_mul(array):
+    a = array.copy()
+    a_np = a.to_numpy()
+
+    # value * array
+    for value in (2.0, 3):
+        result = a * value
+        expected = a_np * value
+        assert len(result) == len(a)
+        np.testing.assert_allclose(result.to_numpy(), expected)
+
+    # value * array
+    np.testing.assert_allclose((1.23 * a).to_numpy(), a_np * 1.23)
+    np.testing.assert_allclose((10 * a).to_numpy(), a_np * 10)
+
+
+def test_array_ops_type_mismatch(array):
+    """Operations against non-array / wrong-type operands are rejected."""
+    with pytest.raises(TypeError):
+        _ = array + 1
+    with pytest.raises(TypeError):
+        _ = array - 1
+    with pytest.raises(TypeError):
+        _ = array * 'x'
+    with pytest.raises(TypeError):
+        _ = 'x' * array
+
+
 def test_current_array_midc(measurement_eis_5freq):
     """Regression test for midc bug.
 

--- a/python/tests/test_curve.py
+++ b/python/tests/test_curve.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from math import isnan
 
+import numpy as np
 import pytest
+
+from pypalmsens.data import Curve
 
 
 @pytest.fixture
@@ -114,3 +117,62 @@ def test_curve_copy(curve_dpv):
     assert curve_dpv._pscurve is not new_curve._pscurve
     assert curve_dpv._pscurve.XAxisDataArray is not new_curve._pscurve.XAxisDataArray
     assert curve_dpv._pscurve.YAxisDataArray is not new_curve._pscurve.YAxisDataArray
+
+
+def test_curve_add(curve_dpv):
+    a = curve_dpv.copy()
+    b = a + a
+
+    result = a + b
+    assert isinstance(result, Curve)
+    assert len(result) == len(a)
+
+    a_np = a.y_array.to_numpy()
+    expected = a_np + b.y_array.to_numpy()
+    np.testing.assert_allclose(result.y_array.to_numpy(), expected)
+
+
+def test_curve_add_commutative(curve_dpv):
+    a = curve_dpv.copy()
+    b = a + a
+
+    np.testing.assert_allclose(
+        (a + b).y_array.to_numpy(),
+        (b + a).y_array.to_numpy(),
+    )
+
+
+def test_curve_sub(curve_dpv):
+    a = curve_dpv.copy()
+    b = a + a
+
+    result = b - a
+    assert isinstance(result, Curve)
+    assert len(result) == len(a)
+    np.testing.assert_allclose(result.y_array.to_numpy(), a.y_array.to_numpy())
+
+    reverse = a - b
+    np.testing.assert_allclose(reverse.y_array.to_numpy(), -a.y_array.to_numpy())
+    np.testing.assert_allclose(reverse.y_array.to_numpy(), -result.y_array.to_numpy())
+
+    zero = a-a
+    np.testing.assert_allclose(zero.y_array.to_numpy(), 0)
+
+
+def test_curve_rsub_direction(curve_dpv):
+    """__rsub__ must compute other - self (operands reversed vs __sub__)."""
+    a = curve_dpv.copy()
+    b = a + a
+
+    result = type(curve_dpv).__rsub__(a, b)
+
+    np.testing.assert_allclose(result.y_array.to_numpy(), (b - a).y_array.to_numpy())
+
+
+def test_curve_add_sub_types(curve_dpv):
+    with pytest.raises(TypeError):
+        _ = curve_dpv + 1
+    with pytest.raises(TypeError):
+        _ = curve_dpv - 1
+    with pytest.raises(TypeError):
+        _ = 1 - curve_dpv


### PR DESCRIPTION
This PR adds arithmetic operations for Curve / DataArray classes.

- `Curve`: `curve_a + curve_b` and `curve_a - curve_b` now return new `Curve` objects
- `DataArray`: `array_a + array_b` and `array_a - array_b` now return new `DataArray` objects.
- `DataArray`: Multiply `array * value` now multiplies by that scalar value and return new `DataArray` objects.