### PR TITLE
Add DataArray.normalize and Curve.concat methods

### DIFF
--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -85,6 +85,23 @@ class Curve:
     def __repr__(self):
         return f'{type(self).__name__}(title={self.title}, n_points={self.n_points})'
 
+    def concat(self, other: Curve) -> Self:
+        """Concatenate the x and y arrays of this curve with another curve.
+
+        Parameters
+        ----------
+        other: Curve
+            Curve whose points are appended after this curve's points.
+
+        Returns
+        -------
+        Curve
+            New curve with the concatenated x and y arrays.
+        """
+        new_curve = PSMath.AppendCurves(self._pscurve, other._pscurve)
+
+        return type(self)(pscurve=new_curve)
+
     def copy(self) -> Curve:
         """Return a copy of this curve."""
         return Curve(pscurve=PSCurve(self._pscurve, cloneData=True))

--- a/python/src/pypalmsens/_data/data_array.py
+++ b/python/src/pypalmsens/_data/data_array.py
@@ -119,6 +119,27 @@ class DataArray(Sequence[float]):
 
     def __rmul__(self, value: object) -> Self:
         return self.__mul__(value)
+
+    def normalize(self) -> Self:
+        """Normalize values in array to the 0 - 1 range.
+
+        Values are scaled with ``(value - min) / (max - min)``,
+        where min and max are the min and max values.
+
+        The unit of the returned array is inherited from the source array.
+
+        Returns
+        -------
+        new_array : DataArray
+            Data array with normalized values.
+        """
+        new_values = PSMath.NormalizeArray(self._psarray.GetValues(), self.min(), self.max())
+        new_array = PSDataArray(
+            self._psarray.Description, self._psarray.Unit, self._psarray.ArrayType
+        )
+        new_array.AddRange(new_values)
+        return type(self)(psarray=new_array)
+
     def copy(self) -> DataArray:
         """Return a copy of the array."""
         return DataArray(psarray=self._psarray.Clone())

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -119,7 +119,7 @@ def test_array_sub(array):
     np.testing.assert_allclose(reverse.to_numpy(), -a.to_numpy())
     np.testing.assert_allclose(reverse.to_numpy(), -result.to_numpy())
 
-    zero = a-a
+    zero = a - a
     np.testing.assert_allclose(zero.to_numpy(), 0)
 
 
@@ -158,6 +158,16 @@ def test_array_ops_type_mismatch(array):
         _ = array * 'x'
     with pytest.raises(TypeError):
         _ = 'x' * array
+
+
+def test_array_normalize(array):
+    assert array.min() != 0
+    assert array.max() != 1
+
+    a = array.normalize()
+
+    assert a.min() == 0
+    assert a.max() == 1
 
 
 def test_current_array_midc(measurement_eis_5freq):

--- a/python/tests/test_curve.py
+++ b/python/tests/test_curve.py
@@ -153,7 +153,7 @@ def test_curve_sub(curve_dpv):
     np.testing.assert_allclose(reverse.y_array.to_numpy(), -a.y_array.to_numpy())
     np.testing.assert_allclose(reverse.y_array.to_numpy(), -result.y_array.to_numpy())
 
-    zero = a-a
+    zero = a - a
     np.testing.assert_allclose(zero.y_array.to_numpy(), 0)
 
 
@@ -189,3 +189,9 @@ def test_curve_remove_baseline(curve_dpv):
     assert list(baseline.y_array) != list(curve_dpv.y_array)
 
     assert sum(curve_dpv.y_array) > sum(corrected.y_array) > sum(baseline.y_array)
+
+
+def test_concat(curve_dpv):
+    c = curve_dpv.concat(curve_dpv)
+    assert len(c) == 2 * len(curve_dpv)
+    assert c.n_points == 2 * curve_dpv.n_points


### PR DESCRIPTION
This PR adds 2 new methods:

- `Curve.concat`

  New method `Curve.concat(other)` that appends another curve's x/y `DataArray` values onto this curve and returns a new `Curve`.

- `DataArray.normalize`

  New method `DataArray.normalize()` that returns a new `DataArray` with values scaled to the `0–1` range:

  ```
  (value - min) / (max - min)
  ```