### PR TITLE
Add constructors for DataArray and Curve objects

### DIFF
--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -380,12 +380,12 @@ class Curve:
     @property
     def x_array(self) -> DataArray:
         """Y data for the curve."""
-        return DataArray(psarray=self._pscurve.XAxisDataArray)
+        return DataArray._wrap(self._pscurve.XAxisDataArray)
 
     @property
     def y_array(self) -> DataArray:
         """Y data for the curve."""
-        return DataArray(psarray=self._pscurve.YAxisDataArray)
+        return DataArray._wrap(self._pscurve.YAxisDataArray)
 
     def linear_slope(
         self, start: None | int = None, stop: None | int = None

--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, NamedTuple, Self, final
 
-import PalmSens
-import PalmSens.Analysis as PSAnalysis
 import System
+from PalmSens import Analysis as PSAnalysis
 from PalmSens.Calculations import MathFunctions as PSMath
 from PalmSens.Plottables import Curve as PSCurve
 from pydantic import TypeAdapter
@@ -257,11 +256,11 @@ class Curve:
             corrected: Curve
             baseline: Curve
 
-        _corrected = PalmSens.Analysis.BaselineCorrection.GetMovingAverageBaselineCorrected(
+        _corrected = PSAnalysis.BaselineCorrection.GetMovingAverageBaselineCorrected(
             self._pscurve, nWindowSize=window_size, maxNSweeps=max_sweeps, baseline=False
         )
         _corrected.Title = self.title + ' (corrected)'
-        _baseline = PalmSens.Analysis.BaselineCorrection.GetMovingAverageBaselineCorrected(
+        _baseline = PSAnalysis.BaselineCorrection.GetMovingAverageBaselineCorrected(
             self._pscurve, nWindowSize=window_size, maxNSweeps=max_sweeps, baseline=True
         )
         _baseline.Title = self.title + ' (baseline)'

--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -388,12 +388,12 @@ class Curve:
     @property
     def x_array(self) -> DataArray:
         """Y data for the curve."""
-        return DataArray._wrap(self._pscurve.XAxisDataArray)
+        return DataArray._wrap_dispatched(self._pscurve.XAxisDataArray)
 
     @property
     def y_array(self) -> DataArray:
         """Y data for the curve."""
-        return DataArray._wrap(self._pscurve.YAxisDataArray)
+        return DataArray._wrap_dispatched(self._pscurve.YAxisDataArray)
 
     def linear_slope(
         self, start: None | int = None, stop: None | int = None

--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -36,6 +36,8 @@ class CurveMetadata:
 
 @final
 class Curve:
+    __slots__ = ('_pscurve',)
+
     """Python wrapper for .NET Curve class.
 
     Parameters
@@ -49,8 +51,14 @@ class Curve:
     ``curve_a - curve_b`` return new curves.
     """
 
-    def __init__(self, *, pscurve: PSCurve):
-        self._pscurve = pscurve
+    def __init__(self, x: DataArray, y: DataArray, *, title: str = 'Curve'):
+        self._pscurve = PSCurve(x._psarray, y._psarray, title)
+
+    @classmethod
+    def _wrap(cls, pscurve: PSCurve) -> Self:
+        obj = cls.__new__(cls)
+        obj._pscurve = pscurve
+        return obj
 
     def __add__(self, other: object) -> Self:
         if not isinstance(other, Curve):
@@ -59,7 +67,7 @@ class Curve:
         operator = PSMath.enumOperator.Add
         new_curve = PSMath.AddSubtractCurves(self._pscurve, other._pscurve, operator)
 
-        return type(self)(pscurve=new_curve)
+        return type(self)._wrap(new_curve)
 
     __radd__ = __add__
 
@@ -70,7 +78,7 @@ class Curve:
         operator = PSMath.enumOperator.Subtract
         new_curve = PSMath.AddSubtractCurves(self._pscurve, other._pscurve, operator)
 
-        return type(self)(pscurve=new_curve)
+        return type(self)._wrap(new_curve)
 
     def __rsub__(self, other: object) -> Self:
         if not isinstance(other, Curve):
@@ -79,7 +87,7 @@ class Curve:
         operator = PSMath.enumOperator.Subtract
         new_curve = PSMath.AddSubtractCurves(other._pscurve, self._pscurve, operator)
 
-        return type(self)(pscurve=new_curve)
+        return type(self)._wrap(new_curve)
 
     @override
     def __repr__(self):
@@ -100,11 +108,11 @@ class Curve:
         """
         new_curve = PSMath.AppendCurves(self._pscurve, other._pscurve)
 
-        return type(self)(pscurve=new_curve)
+        return type(self)._wrap(new_curve)
 
     def copy(self) -> Curve:
         """Return a copy of this curve."""
-        return Curve(pscurve=PSCurve(self._pscurve, cloneData=True))
+        return Curve._wrap(PSCurve(self._pscurve, cloneData=True))
 
     def smooth(self, smooth_level: int = 0):
         """Smooth the .y_array using a Savitsky-Golay filter with the specified smooth
@@ -259,7 +267,7 @@ class Curve:
         _baseline.Title = self.title + ' (baseline)'
 
         return BaselineResult(
-            corrected=Curve(pscurve=_corrected), baseline=Curve(pscurve=_baseline)
+            corrected=Curve._wrap(_corrected), baseline=Curve._wrap(_baseline)
         )
 
     @property

--- a/python/src/pypalmsens/_data/data_array.py
+++ b/python/src/pypalmsens/_data/data_array.py
@@ -268,8 +268,17 @@ class CurrentArray(DataArray):
 
     Parameters
     ----------
-    psarray
-        Reference to .NET DataArray object.
+    values : Iterable[float]
+        Values to store in the array.
+        Any iterable (list, tuple, generator, etc.)
+        of floats is accepted.
+    array_type : AllowedArrayTypes, optional
+        Type of the array. Defaults to `'Generic'`.
+        Use e.g. `'Current'` or `'Potential'` when constructing
+        arrays that represent measured quantities.
+    name : str, optional
+        Name of the array. Defaults to the value of `array_type` when not
+        given. The name is used in `__repr__` and for identification.
     """
 
     __slots__ = ()

--- a/python/src/pypalmsens/_data/data_array.py
+++ b/python/src/pypalmsens/_data/data_array.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Self, overload
 
 import numpy as np
+from PalmSens import Units as PSUnits
 from PalmSens.Calculations import MathFunctions as PSMath
 from PalmSens.Data import DataArray as PSDataArray
 from PalmSens.Data import DataArrayCurrents as PSDataArrayCurrents
@@ -30,6 +31,31 @@ def implementation(interface):
     # if you need to "downcast" to the implementation class.
     # https://github.com/pythonnet/pythonnet/blob/a404d6e4d2ef6182763bd626ab08e0de4400e621/CHANGELOG.md?plain=1#L73-L77
     return interface.__implementation__
+
+
+DEFAULT_UNIT_MAPPING = {
+    'Time': PSUnits.Time,
+    'Potential': PSUnits.Volt,
+    'Current': PSUnits.MicroAmpere,
+    'Charge': PSUnits.MicroCoulomb,
+    'Temperature': PSUnits.Temperature,
+    'ExtraValue': PSUnits.Volt,
+    'AuxInput': PSUnits.Volt,
+    'ZRe': PSUnits.ZRe,
+    'ZIm': PSUnits.ZIm,
+    'Z': PSUnits.Z,
+    'Y': PSUnits.Y,
+    'YRe': PSUnits.YRe,
+    'YIm': PSUnits.YIm,
+    'Phase': PSUnits.Phase,
+    'Frequency': PSUnits.Hertz,
+    'Cs': PSUnits.Farad,
+    'CsRe': PSUnits.FahradReal,
+    'CsIm': PSUnits.FahradImaginary,
+    'mEdc': PSUnits.Volt,
+    'Eac': PSUnits.Volt,
+    'Idc': PSUnits.MicroAmpere,
+}
 
 
 class DataArray(Sequence[float]):
@@ -75,9 +101,17 @@ class DataArray(Sequence[float]):
         if name is None:
             name = array_type
 
-        unit = PSDataArray.GetDefaultUnit(array_type_enum)
+        if isinstance(self, CurrentArray):
+            new_array = PSDataArrayCurrents(name, array_type_enum)
+        elif isinstance(self, PotentialArray):
+            new_array = PSDataArrayPotentials(name, array_type_enum)
+        else:
+            try:
+                unit = DEFAULT_UNIT_MAPPING[array_type]()
+            except KeyError:
+                unit = PSUnits.FixedUnit('Unknown', '', '')
 
-        new_array = self._ps_cls(name, unit, array_type_enum)
+            new_array = self._ps_cls(name, unit, array_type_enum)
 
         new_array.AddRange(values)
 
@@ -285,8 +319,16 @@ class CurrentArray(DataArray):
 
     _ps_cls: ClassVar[type[PSDataArray]] = PSDataArrayCurrents
 
+    def __init__(
+        self,
+        values: Iterable[float],
+        *,
+        name: str | None = None,
+    ):
+        super().__init__(values, array_type='Current', name=name)
+
     def current(self) -> list[float]:
-        """Current in uA."""
+        """Current in µA."""
         # Work-around for mIDC bug
         if self.type == 'miDC':
             return [implementation(val).Value for val in self._psarray]
@@ -374,6 +416,14 @@ class PotentialArray(DataArray):
     __slots__ = ()
 
     _ps_cls: ClassVar[type[PSDataArray]] = PSDataArrayPotentials
+
+    def __init__(
+        self,
+        values: Iterable[float],
+        *,
+        name: str | None = None,
+    ):
+        super().__init__(values, array_type='Potential', name=name)
 
     def potential(self) -> list[float]:
         """Return list of potential values in V."""

--- a/python/src/pypalmsens/_data/data_array.py
+++ b/python/src/pypalmsens/_data/data_array.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Self, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Self, overload
 
 import numpy as np
+import PalmSens
 from PalmSens.Calculations import MathFunctions as PSMath
 from PalmSens.Data import DataArray as PSDataArray
 from typing_extensions import override
@@ -31,7 +32,7 @@ def implementation(interface):
 
 
 class DataArray(Sequence[float]):
-    """Python wrapper for .NET DataArray class.
+    """Array of data values.
 
     A data array can be created from an iterable of values, or wrapped from an
     existing ``PSDataArray`` (see ``_wrap``).
@@ -57,7 +58,8 @@ class DataArray(Sequence[float]):
     ``array_a * factor`` return new arrays.
     """
 
-    __slots__ = ('_psarray',)
+    __slots__: ClassVar[tuple[str, ...]] = ('_psarray',)
+    _psarray: PSDataArray
 
     def __init__(
         self,
@@ -83,6 +85,17 @@ class DataArray(Sequence[float]):
         obj = cls.__new__(cls)
         obj._psarray = psarray
         return obj
+
+    @classmethod
+    def _wrap_dispatched(
+        cls, psarray: PSDataArray
+    ) -> DataArray | CurrentArray | PotentialArray:
+        if isinstance(psarray, PalmSens.Data.DataArrayPotentials):
+            return PotentialArray._wrap(psarray)
+        if isinstance(psarray, PalmSens.Data.DataArrayCurrents):
+            return CurrentArray._wrap(psarray)
+
+        return DataArray._wrap(psarray)
 
     @override
     def __repr__(self):
@@ -110,7 +123,7 @@ class DataArray(Sequence[float]):
     def __len__(self) -> int:
         return len(self._psarray)
 
-    def __add__(self, other: object) -> Self:
+    def __add__(self, other: object) -> DataArray:
         if not isinstance(other, self.__class__):
             return NotImplemented
 
@@ -119,10 +132,10 @@ class DataArray(Sequence[float]):
 
         return type(self)._wrap(new_array)
 
-    def __radd__(self, other: object) -> Self:
+    def __radd__(self, other: object) -> DataArray:
         return self.__add__(other)
 
-    def __sub__(self, other: object) -> Self:
+    def __sub__(self, other: object) -> DataArray:
         if not isinstance(other, self.__class__):
             return NotImplemented
 
@@ -131,7 +144,7 @@ class DataArray(Sequence[float]):
 
         return type(self)._wrap(new_array)
 
-    def __rsub__(self, other: object) -> Self:
+    def __rsub__(self, other: object) -> DataArray:
         if not isinstance(other, self.__class__):
             return NotImplemented
 
@@ -140,7 +153,7 @@ class DataArray(Sequence[float]):
 
         return type(self)._wrap(new_array)
 
-    def __mul__(self, value: object) -> Self:
+    def __mul__(self, value: object) -> DataArray:
         if not isinstance(value, (int, float)):
             return NotImplemented
 
@@ -153,10 +166,10 @@ class DataArray(Sequence[float]):
 
         return type(self)._wrap(new_array)
 
-    def __rmul__(self, value: object) -> Self:
+    def __rmul__(self, value: object) -> DataArray:
         return self.__mul__(value)
 
-    def normalize(self) -> Self:
+    def normalize(self) -> DataArray:
         """Normalize values in array to the 0 - 1 range.
 
         Values are scaled with ``(value - min) / (max - min)``,
@@ -256,6 +269,8 @@ class CurrentArray(DataArray):
         Reference to .NET DataArray object.
     """
 
+    __slots__ = ()
+
     def current(self) -> list[float]:
         """Current in uA."""
         # Work-around for mIDC bug
@@ -329,9 +344,20 @@ class PotentialArray(DataArray):
 
     Parameters
     ----------
-    psarray
-        Reference to .NET DataArray object.
+    values : Iterable[float]
+        Values to store in the array.
+        Any iterable (list, tuple, generator, etc.)
+        of floats is accepted.
+    array_type : AllowedArrayTypes, optional
+        Type of the array. Defaults to `'Generic'`.
+        Use e.g. `'Current'` or `'Potential'` when constructing
+        arrays that represent measured quantities.
+    name : str, optional
+        Name of the array. Defaults to the value of `array_type` when not
+        given. The name is used in `__repr__` and for identification.
     """
+
+    __slots__ = ()
 
     def potential(self) -> list[float]:
         """Return list of potential values in V."""

--- a/python/src/pypalmsens/_data/data_array.py
+++ b/python/src/pypalmsens/_data/data_array.py
@@ -31,14 +31,24 @@ def implementation(interface):
 
 
 class DataArray(Sequence[float]):
-    __slots__ = ('_psarray',)
-
     """Python wrapper for .NET DataArray class.
+
+    A data array can be created from an iterable of values, or wrapped from an
+    existing ``PSDataArray`` (see ``_wrap``).
 
     Parameters
     ----------
-    psarray
-        Reference to .NET DataArray object.
+    values : Iterable[float]
+        Values to store in the array.
+        Any iterable (list, tuple, generator, etc.)
+        of floats is accepted.
+    array_type : AllowedArrayTypes, optional
+        Type of the array. Defaults to `'Generic'`.
+        Use e.g. `'Current'` or `'Potential'` when constructing
+        arrays that represent measured quantities.
+    name : str, optional
+        Name of the array. Defaults to the value of `array_type` when not
+        given. The name is used in `__repr__` and for identification.
 
     Notes
     -----
@@ -47,8 +57,14 @@ class DataArray(Sequence[float]):
     ``array_a * factor`` return new arrays.
     """
 
+    __slots__ = ('_psarray',)
+
     def __init__(
-        self, values: Iterable[float], *, array_type: AllowedArrayTypes, name: str | None = None
+        self,
+        values: Iterable[float],
+        *,
+        array_type: AllowedArrayTypes = 'Generic',
+        name: str | None = None,
     ):
         array_type_enum = array_str_to_enum(array_type)
 

--- a/python/src/pypalmsens/_data/data_array.py
+++ b/python/src/pypalmsens/_data/data_array.py
@@ -4,9 +4,10 @@ from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Self, overload
 
 import numpy as np
-import PalmSens
 from PalmSens.Calculations import MathFunctions as PSMath
 from PalmSens.Data import DataArray as PSDataArray
+from PalmSens.Data import DataArrayCurrents as PSDataArrayCurrents
+from PalmSens.Data import DataArrayPotentials as PSDataArrayPotentials
 from typing_extensions import override
 
 from .._converters import cr_enum_to_string, pr_enum_to_string
@@ -60,6 +61,7 @@ class DataArray(Sequence[float]):
 
     __slots__: ClassVar[tuple[str, ...]] = ('_psarray',)
     _psarray: PSDataArray
+    _ps_cls: ClassVar[type[PSDataArray]] = PSDataArray
 
     def __init__(
         self,
@@ -75,7 +77,8 @@ class DataArray(Sequence[float]):
 
         unit = PSDataArray.GetDefaultUnit(array_type_enum)
 
-        new_array = PSDataArray(name, unit, array_type_enum)
+        new_array = self._ps_cls(name, unit, array_type_enum)
+
         new_array.AddRange(values)
 
         self._psarray = new_array
@@ -90,9 +93,9 @@ class DataArray(Sequence[float]):
     def _wrap_dispatched(
         cls, psarray: PSDataArray
     ) -> DataArray | CurrentArray | PotentialArray:
-        if isinstance(psarray, PalmSens.Data.DataArrayPotentials):
+        if isinstance(psarray, PSDataArrayPotentials):
             return PotentialArray._wrap(psarray)
-        if isinstance(psarray, PalmSens.Data.DataArrayCurrents):
+        if isinstance(psarray, PSDataArrayCurrents):
             return CurrentArray._wrap(psarray)
 
         return DataArray._wrap(psarray)
@@ -271,6 +274,8 @@ class CurrentArray(DataArray):
 
     __slots__ = ()
 
+    _ps_cls: ClassVar[type[PSDataArray]] = PSDataArrayCurrents
+
     def current(self) -> list[float]:
         """Current in uA."""
         # Work-around for mIDC bug
@@ -358,6 +363,8 @@ class PotentialArray(DataArray):
     """
 
     __slots__ = ()
+
+    _ps_cls: ClassVar[type[PSDataArray]] = PSDataArrayPotentials
 
     def potential(self) -> list[float]:
         """Return list of potential values in V."""

--- a/python/src/pypalmsens/_data/data_array.py
+++ b/python/src/pypalmsens/_data/data_array.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Self, overload
 
 import numpy as np
@@ -16,7 +16,7 @@ from .._types import (
     AllowedTimingStatus,
 )
 from .data_value import CurrentReading, PotentialReading
-from .types import AllowedArrayTypes, array_enum_to_str
+from .types import AllowedArrayTypes, array_enum_to_str, array_str_to_enum
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -31,6 +31,8 @@ def implementation(interface):
 
 
 class DataArray(Sequence[float]):
+    __slots__ = ('_psarray',)
+
     """Python wrapper for .NET DataArray class.
 
     Parameters
@@ -45,8 +47,26 @@ class DataArray(Sequence[float]):
     ``array_a * factor`` return new arrays.
     """
 
-    def __init__(self, *, psarray: PSDataArray):
-        self._psarray: PSDataArray = psarray
+    def __init__(
+        self, values: Iterable[float], *, array_type: AllowedArrayTypes, name: str | None = None
+    ):
+        array_type_enum = array_str_to_enum(array_type)
+
+        if name is None:
+            name = array_type
+
+        unit = PSDataArray.GetDefaultUnit(array_type_enum)
+
+        new_array = PSDataArray(name, unit, array_type_enum)
+        new_array.AddRange(values)
+
+        self._psarray = new_array
+
+    @classmethod
+    def _wrap(cls, psarray: PSDataArray) -> Self:
+        obj = cls.__new__(cls)
+        obj._psarray = psarray
+        return obj
 
     @override
     def __repr__(self):
@@ -81,7 +101,7 @@ class DataArray(Sequence[float]):
         operator = PSMath.enumOperator.Add
         new_array = PSMath.AddSubtractDataArrays(self._psarray, other._psarray, operator)
 
-        return type(self)(psarray=new_array)
+        return type(self)._wrap(new_array)
 
     def __radd__(self, other: object) -> Self:
         return self.__add__(other)
@@ -93,7 +113,7 @@ class DataArray(Sequence[float]):
         operator = PSMath.enumOperator.Subtract
         new_array = PSMath.AddSubtractDataArrays(self._psarray, other._psarray, operator)
 
-        return type(self)(psarray=new_array)
+        return type(self)._wrap(new_array)
 
     def __rsub__(self, other: object) -> Self:
         if not isinstance(other, self.__class__):
@@ -102,7 +122,7 @@ class DataArray(Sequence[float]):
         operator = PSMath.enumOperator.Subtract
         new_array = PSMath.AddSubtractDataArrays(other._psarray, self._psarray, operator)
 
-        return type(self)(psarray=new_array)
+        return type(self)._wrap(new_array)
 
     def __mul__(self, value: object) -> Self:
         if not isinstance(value, (int, float)):
@@ -115,7 +135,7 @@ class DataArray(Sequence[float]):
         )
         new_array.AddRange(new_values)
 
-        return type(self)(psarray=new_array)
+        return type(self)._wrap(new_array)
 
     def __rmul__(self, value: object) -> Self:
         return self.__mul__(value)
@@ -138,11 +158,11 @@ class DataArray(Sequence[float]):
             self._psarray.Description, self._psarray.Unit, self._psarray.ArrayType
         )
         new_array.AddRange(new_values)
-        return type(self)(psarray=new_array)
+        return type(self)._wrap(new_array)
 
     def copy(self) -> DataArray:
         """Return a copy of the array."""
-        return DataArray(psarray=self._psarray.Clone())
+        return DataArray._wrap(self._psarray.Clone())
 
     def min(self) -> float:
         """Return min value."""

--- a/python/src/pypalmsens/_data/data_value.py
+++ b/python/src/pypalmsens/_data/data_value.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import PalmSens
+from PalmSens import Data as PSData
 from typing_extensions import override
 
 from .._converters import (
@@ -44,7 +44,7 @@ class PotentialReading:
         return f'{self.potential:.3f} V'
 
     @classmethod
-    def _from_psobject(cls, obj: PalmSens.Data.VoltageReading):
+    def _from_psobject(cls, obj: PSData.VoltageReading):
         return cls(
             potential_range=pr_enum_to_string(obj.Range),
             potential=obj.Value,
@@ -81,7 +81,7 @@ class CurrentReading:
         return f'{self.current_in_range:.3f} * {self.current_range}'
 
     @classmethod
-    def _from_psobject(cls, obj: PalmSens.Data.CurrentReading):
+    def _from_psobject(cls, obj: PSData.CurrentReading):
         return cls(
             current_range=cr_enum_to_string(obj.CurrentRange),
             current=obj.Value,

--- a/python/src/pypalmsens/_data/dataset.py
+++ b/python/src/pypalmsens/_data/dataset.py
@@ -60,7 +60,7 @@ def _dataset_to_mapping_with_unique_keys(psdataset: PSDataSet, /) -> dict[str, D
         else:
             cls = DataArray  # type: ignore
 
-        mapping[key] = cls(psarray=array)
+        mapping[key] = cls._wrap(array)
 
     return mapping
 
@@ -178,7 +178,7 @@ class DataSet(Mapping[str, DataArray]):
         elif quantity:
             return self._filter(key=lambda array: array.quantity == quantity)
         elif hidden:
-            return [DataArray(psarray=psarray) for psarray in self._psdataset if psarray.Hidden]
+            return [DataArray._wrap(psarray) for psarray in self._psdataset if psarray.Hidden]
         else:
             return list(self.values())
 

--- a/python/src/pypalmsens/_data/dataset.py
+++ b/python/src/pypalmsens/_data/dataset.py
@@ -35,7 +35,7 @@ def _dataset_to_mapping_with_unique_keys(psdataset: PSDataSet, /) -> dict[str, D
         else:
             key = array_type
 
-        mapping[key] = DataArray._wrap(array)
+        mapping[key] = DataArray._wrap_dispatched(array)
 
     return mapping
 

--- a/python/src/pypalmsens/_data/dataset.py
+++ b/python/src/pypalmsens/_data/dataset.py
@@ -7,7 +7,7 @@ from PalmSens.Plottables import Curve as PSCurve
 from typing_extensions import override
 
 from .curve import Curve
-from .data_array import CurrentArray, DataArray, PotentialArray
+from .data_array import CurrentArray, DataArray
 from .types import AllowedArrayTypes, array_enum_to_str
 
 if TYPE_CHECKING:
@@ -18,24 +18,6 @@ if TYPE_CHECKING:
 
 def _dataset_to_mapping_with_unique_keys(psdataset: PSDataSet, /) -> dict[str, DataArray]:
     """Suffix non-unique keys with integer. Keys are derived from the array type."""
-    CURRENT_TYPES = (
-        'Current',
-        'Iac',
-        'miDC',
-        'BipotCurrent',
-        'ForwardCurrent',
-        'ReverseCurrent',
-        'CurrentExtraWE',
-        'DCCurrent',
-    )
-    POTENTIAL_TYPES = (
-        'Potential',
-        'BipotPotential',
-        'CEPotential',
-        'SE2vsXPotential',
-        'PotentialExtraRE',
-    )
-
     arrays: list[PSDataArray] = [array for array in psdataset.GetDataArrays()]
     array_types = [array_enum_to_str(array.ArrayType) for array in arrays]
 
@@ -53,14 +35,7 @@ def _dataset_to_mapping_with_unique_keys(psdataset: PSDataSet, /) -> dict[str, D
         else:
             key = array_type
 
-        if array_type in CURRENT_TYPES:
-            cls = CurrentArray  # type: ignore
-        elif array_type in POTENTIAL_TYPES:
-            cls = PotentialArray  # type: ignore
-        else:
-            cls = DataArray  # type: ignore
-
-        mapping[key] = cls._wrap(array)
+        mapping[key] = DataArray._wrap(array)
 
     return mapping
 

--- a/python/src/pypalmsens/_data/dataset.py
+++ b/python/src/pypalmsens/_data/dataset.py
@@ -113,7 +113,7 @@ class DataSet(Mapping[str, DataArray]):
 
         pscurve = PSCurve(xarray._psarray, yarray._psarray, title=title)
 
-        return Curve(pscurve=pscurve)
+        return Curve._wrap(pscurve)
 
     def arrays(
         self,

--- a/python/src/pypalmsens/_data/eisdata.py
+++ b/python/src/pypalmsens/_data/eisdata.py
@@ -147,7 +147,7 @@ class EISData:
             raise ValueError(f'Frequency must be between 0 and {self.n_frequencies}')
 
         return {
-            str(row.Key): DataArray(psarray=row.Value)
+            str(row.Key): DataArray._wrap(row.Value)
             for row in self._pseis.GetDataArrayVsX(frequency)
         }
 

--- a/python/src/pypalmsens/_data/measurement.py
+++ b/python/src/pypalmsens/_data/measurement.py
@@ -127,7 +127,7 @@ class Measurement:
         """
         curve = self._psmeasurement.BlankCurve
         if curve:
-            return Curve(pscurve=curve)
+            return Curve._wrap(curve)
         return None
 
     @property
@@ -219,4 +219,4 @@ class Measurement:
         curves : list[Curve]
             List of curves
         """
-        return [Curve(pscurve=curve) for curve in self._psmeasurement.GetCurveArray()]
+        return [Curve._wrap(curve) for curve in self._psmeasurement.GetCurveArray()]

--- a/python/src/pypalmsens/_data/peak.py
+++ b/python/src/pypalmsens/_data/peak.py
@@ -47,7 +47,7 @@ class Peak:
         from .curve import Curve
 
         if not self._curve:
-            self._curve = Curve(pscurve=self._pspeak.Curve)
+            self._curve = Curve._wrap(self._pspeak.Curve)
         return self._curve
 
     @property

--- a/python/src/pypalmsens/_fitting.py
+++ b/python/src/pypalmsens/_fitting.py
@@ -4,8 +4,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
-import PalmSens
 import System
+from PalmSens import Fitting as PSFitting
+from PalmSens.Fitting import Models as PSModels
 from typing_extensions import override
 
 from ._data.curve import Curve
@@ -31,7 +32,7 @@ class Parameter:
     """If True, fix the value for this parameter."""
 
     @classmethod
-    def _import(cls, psparameter: PalmSens.Fitting.Parameter):
+    def _import(cls, psparameter: PSFitting.Parameter):
         """Create instance from SDK Parameter object."""
         return cls(
             symbol=psparameter.Symbol,
@@ -41,7 +42,7 @@ class Parameter:
             fixed=psparameter.Fixed,
         )
 
-    def _export(self, psparameter: PalmSens.Fitting.Parameter):
+    def _export(self, psparameter: PSFitting.Parameter):
         """Update PalmSens SDK object with values from dataclass."""
         if self.value is not None:
             psparameter.Value = self.value
@@ -74,7 +75,7 @@ class Parameters(Sequence[Parameter]):
         self.cdc: str = cdc
         """CDC code used to generate parameter listing."""
 
-        model = PalmSens.Fitting.Models.CircuitModel()
+        model = PSModels.CircuitModel()
         model.SetCircuit(cdc)
         self._parameters: list[Parameter] = [
             Parameter._import(psparam) for psparam in model.InitialParameters
@@ -96,7 +97,7 @@ class Parameters(Sequence[Parameter]):
     def __str__(self) -> str:
         return self._parameters.__str__()
 
-    def _export(self, psmodel: PalmSens.Fitting.Models.CircuitModel) -> None:
+    def _export(self, psmodel: PSModels.CircuitModel) -> None:
         """Update the initial parameters in the SDK model with parameters in this instance.
 
         Note that the length and type of parameters must match that of the SDK class.
@@ -126,7 +127,7 @@ class FitResult:
     """Exit code for the minimization."""
 
     @classmethod
-    def from_psfitresult_nelder_mead(cls, result: PalmSens.Fitting.FitResult, cdc: str):
+    def from_psfitresult_nelder_mead(cls, result: PSFitting.FitResult, cdc: str):
         """Construct fitresult from SDK FitResult."""
         exit_codes = {
             0: 'None',
@@ -149,7 +150,7 @@ class FitResult:
         )
 
     @classmethod
-    def from_psfitresult(cls, result: PalmSens.Fitting.FitResult, cdc: str):
+    def from_psfitresult(cls, result: PSFitting.FitResult, cdc: str):
         """Construct fitresult from SDK FitResult."""
         if result.ParameterSDs:
             error = list(result.ParameterSDs)
@@ -177,9 +178,9 @@ class FitResult:
             n_iter=0,
         )
 
-    def get_psmodel(self, data: EISData) -> PalmSens.Fitting.Models.CircuitModel:
+    def get_psmodel(self, data: EISData) -> PSModels.CircuitModel:
         """Get SDK Circuit model object."""
-        psmodel = PalmSens.Fitting.Models.CircuitModel()
+        psmodel = PSModels.CircuitModel()
         psmodel.SetEISdata(data._pseis)
         psmodel.SetCircuit(self.cdc)
         psmodel.SetInitialParameters(self.parameters)
@@ -372,7 +373,7 @@ class CircuitModel:
     """Lambda Scaling Factor. Levenberg-Marquardt only (default = 10)."""
 
     _last_result: None | FitResult = field(default=None, repr=False)
-    _last_psfitter: None | PalmSens.Fitting.FitAlgorithm = field(default=None, repr=False)
+    _last_psfitter: None | PSFitting.FitAlgorithm = field(default=None, repr=False)
 
     def default_parameters(self) -> Parameters:
         """Get default parameters. Use this to modify parameter values.
@@ -389,7 +390,7 @@ class CircuitModel:
         data: EISData,
         *,
         parameters: None | Sequence[float] | Parameters = None,
-    ) -> PalmSens.Fitting.FitOptions:
+    ) -> PSFitting.FitOptions:
         """Fit circuit model.
 
         Parameters
@@ -402,10 +403,10 @@ class CircuitModel:
 
         Returns
         -------
-        opts : PalmSens.Fitting.FitOptions
+        opts : PSFitting.FitOptions
             SDK object containing fitting options.
         """
-        model = PalmSens.Fitting.Models.CircuitModel()
+        model = PSModels.CircuitModel()
         model.SetCircuit(self.cdc)
         model.SetEISdata(data._pseis)
 
@@ -421,7 +422,7 @@ class CircuitModel:
                     raise ValueError(f'Parameters must be of length {model.NParameters}')
                 model.SetInitialParameters(parameters)
 
-        opts = PalmSens.Fitting.FitOptionsCircuit()
+        opts = PSFitting.FitOptionsCircuit()
         opts.Model = model
         opts.RawData = data._pseis
 
@@ -430,9 +431,9 @@ class CircuitModel:
         opts.MinimumDeltaParameters = self.min_delta_step
 
         if self.algorithm == 'leastsq':
-            opts.SelectedAlgorithm = PalmSens.Fitting.Algorithm.LevenbergMarquardt
+            opts.SelectedAlgorithm = PSFitting.Algorithm.LevenbergMarquardt
         elif self.algorithm == 'nelder-mead':
-            opts.SelectedAlgorithm = PalmSens.Fitting.Algorithm.NelderMead
+            opts.SelectedAlgorithm = PSFitting.Algorithm.NelderMead
         else:
             raise ValueError(f'{self.algorithm=}')
 
@@ -490,7 +491,7 @@ class CircuitModel:
 
         opts = self._psfitoptions(data=data, parameters=parameters)
 
-        fitter = PalmSens.Fitting.FitAlgorithm.FromAlgorithm(opts)
+        fitter = PSFitting.FitAlgorithm.FromAlgorithm(opts)
         fitter.ApplyFitCircuit()
         self._last_psfitter = fitter
         if self.algorithm == 'nelder-mead':

--- a/python/src/pypalmsens/_fitting.py
+++ b/python/src/pypalmsens/_fitting.py
@@ -201,7 +201,7 @@ class FitResult:
         """
         psmodel = self.get_psmodel(data=data)
         curves = psmodel.GetNyquist()
-        calc, meas = (Curve(pscurve=pscurve) for pscurve in curves)
+        calc, meas = (Curve._wrap(pscurve) for pscurve in curves)
         return calc, meas
 
     def get_bode_z(self, data: EISData) -> tuple[Curve, Curve]:
@@ -220,7 +220,7 @@ class FitResult:
         """
         psmodel = self.get_psmodel(data=data)
         curves = psmodel.GetCurveZabsOverFrequency(False)
-        calc, meas = (Curve(pscurve=pscurve) for pscurve in curves)
+        calc, meas = (Curve._wrap(pscurve) for pscurve in curves)
         return calc, meas
 
     def get_bode_phase(self, data: EISData) -> tuple[Curve, Curve]:
@@ -239,7 +239,7 @@ class FitResult:
         """
         psmodel = self.get_psmodel(data=data)
         curves = psmodel.GetCurvePhaseOverFrequency(False)
-        calc, meas = (Curve(pscurve=pscurve) for pscurve in curves)
+        calc, meas = (Curve._wrap(pscurve) for pscurve in curves)
         return calc, meas
 
     def plot_nyquist(self, data: EISData) -> figure.Figure:

--- a/python/src/pypalmsens/_instruments/callback.py
+++ b/python/src/pypalmsens/_instruments/callback.py
@@ -4,8 +4,7 @@ from collections.abc import Generator
 from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol
 
-import PalmSens
-from PalmSens.Comm import StatusEventArgs
+from PalmSens import Comm as PSComm
 from typing_extensions import override
 
 from pypalmsens._converters import single_to_double
@@ -144,12 +143,12 @@ class CallbackEIS(Protocol):
 class Status:
     """Device Status class."""
 
-    _status: PalmSens.Comm.Status = field(repr=False)
+    _status: PSComm.Status = field(repr=False)
     device_state: AllowedDeviceState = 'Unknown'
     """Device state."""
 
     @classmethod
-    def _from_event_args(cls, args: StatusEventArgs) -> Status:
+    def _from_event_args(cls, args: PSComm.StatusEventArgs) -> Status:
         return cls(
             _status=args.GetStatus(),
             device_state=str(args.DeviceState),  # type:ignore

--- a/python/src/pypalmsens/_instruments/capabilities.py
+++ b/python/src/pypalmsens/_instruments/capabilities.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import Literal
 
-import PalmSens
 import System
+from PalmSens import Comm as PSComm
+from PalmSens import Devices as PSDevices
+from PalmSens import Method as PSMethod
 from pydantic import BaseModel, ConfigDict, computed_field
 
 from .._converters import (
@@ -51,7 +53,7 @@ class AnalogComponent(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     @classmethod
-    def _from_pscomponent(cls, obj: PalmSens.Devices.AnalogComponent) -> AnalogComponent:
+    def _from_pscomponent(cls, obj: PSDevices.AnalogComponent) -> AnalogComponent:
         """Convert dotnet object."""
         return cls(
             bits=obj.Bits,
@@ -69,7 +71,7 @@ class AnalogComponent(BaseModel):
 class CapabilitiesInterface(BaseModel):
     """Interface to convert from PalmSens.Devices.Capabilities to dataclass."""
 
-    comm: PalmSens.Comm.CommManager
+    comm: PSComm.CommManager
 
     model_config = ConfigDict(
         frozen=True,
@@ -339,7 +341,7 @@ class CapabilitiesInterface(BaseModel):
 
         for number in self.comm.Capabilities.SupportedMethods:
             try:
-                id = PalmSens.Method.FromTechniqueNumber(number).MethodID
+                id = PSMethod.FromTechniqueNumber(number).MethodID
             except System.Exception:
                 pass
             else:
@@ -507,7 +509,7 @@ class Capabilities(BaseModel):
     """Whether the device contains and supports insternal storage"""
 
     @classmethod
-    def _from_comm(cls, comm: PalmSens.Comm.CommManager) -> Capabilities:
+    def _from_comm(cls, comm: PSComm.CommManager) -> Capabilities:
         """Initialize model from comm manager."""
         interface = CapabilitiesInterface(comm=comm)
         return cls.model_validate(interface.model_dump())

--- a/python/src/pypalmsens/_instruments/capabilities_mixin.py
+++ b/python/src/pypalmsens/_instruments/capabilities_mixin.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Protocol
 
-import PalmSens
-from PalmSens.Comm import CommManager
+from PalmSens import Comm as PSComm
+from PalmSens import Method as PSMethod
 
 from .._types import (
     AllowedCurrentRanges,
@@ -16,7 +16,7 @@ from .shared import MethodIncompatibleError
 
 
 class HasCommProtocol(Protocol):
-    _comm: CommManager
+    _comm: PSComm.CommManager
 
     def ensure_connection(self) -> None: ...
 
@@ -95,7 +95,7 @@ class CapabilitiesMixin:
 
     def get_estimated_duration(
         self: HasCommProtocol,
-        method: PalmSens.Method | MethodTypeCompatible,
+        method: PSMethod | MethodTypeCompatible,
     ) -> float:
         """Get the estimated duration for this method.
 
@@ -111,7 +111,7 @@ class CapabilitiesMixin:
         """
         self.ensure_connection()
 
-        if not isinstance(method, PalmSens.Method):
+        if not isinstance(method, PSMethod):
             method = method._to_psmethod()
 
         capabilities = self._comm.Capabilities

--- a/python/src/pypalmsens/_instruments/comm_protocol.py
+++ b/python/src/pypalmsens/_instruments/comm_protocol.py
@@ -4,7 +4,7 @@ import re
 import time
 from collections import deque
 
-import PalmSens
+from PalmSens import Devices as PSDevices
 from typing_extensions import Generator, Self, override
 
 from .comm_registry import (
@@ -56,7 +56,7 @@ class CommProtocol:
         self.instrument: Instrument = instrument
         """Instrument handle."""
 
-        self._device: PalmSens.Devices.Device = self.instrument.device
+        self._device: PSDevices.Device = self.instrument.device
         """Low-level device implementing low-level communication primitives."""
 
         self.timeout: float = 10.0  # s

--- a/python/src/pypalmsens/_instruments/comm_protocol_async.py
+++ b/python/src/pypalmsens/_instruments/comm_protocol_async.py
@@ -5,7 +5,7 @@ import time
 from collections import deque
 from collections.abc import AsyncIterator
 
-import PalmSens
+from PalmSens import Devices as PSDevices
 from typing_extensions import Self, override
 
 from .comm_protocol import ERROR_PATTERN, CommProtocolError, parse_capabilities
@@ -30,7 +30,7 @@ class CommProtocolAsync:
         self.instrument: Instrument = instrument
         """Instrument handle."""
 
-        self._device: PalmSens.Devices.Device = self.instrument.device
+        self._device: PSDevices.Device = self.instrument.device
         """Low-level device implementing low-level communication primitives."""
 
         self.timeout: float = 10.0  # s

--- a/python/src/pypalmsens/_instruments/filesystem.py
+++ b/python/src/pypalmsens/_instruments/filesystem.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import sys
 from collections.abc import Iterator
 
-import PalmSens
 import System
-from PalmSens.Data import DeviceFile
+from PalmSens import Comm as PSComm
+from PalmSens import Data as PSData
 from typing_extensions import override
 
 from ..data import Measurement
@@ -93,7 +93,7 @@ class DeviceFileSystem:
             self.manager = instrument_or_manager
 
     @property
-    def _client_connection(self) -> PalmSens.Comm.ClientConnection:
+    def _client_connection(self) -> PSComm.ClientConnection:
         """The active client connection used for device communication."""
         return self.manager._comm.ClientConnection
 
@@ -119,7 +119,7 @@ class DeviceFileSystem:
         """Join a path component to the root directory."""
         return self.root / path_str
 
-    def _get_device_file(self, path: str | DevicePath) -> PalmSens.Data.DeviceFile:
+    def _get_device_file(self, path: str | DevicePath) -> PSData.DeviceFile:
         """Retrieve the DeviceFile` for the given path."""
         if not isinstance(path, DevicePath):
             path = DevicePath(path)
@@ -138,7 +138,9 @@ class DeviceFileSystem:
         path._cached_device_file = ret  # type: ignore
         return ret
 
-    def _get_device_files(self, directory: DevicePath | str | None = None) -> list[DeviceFile]:
+    def _get_device_files(
+        self, directory: DevicePath | str | None = None
+    ) -> list[PSData.DeviceFile]:
         if not directory:
             directory = self.root
 

--- a/python/src/pypalmsens/_instruments/filesystem_async.py
+++ b/python/src/pypalmsens/_instruments/filesystem_async.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 
-import PalmSens
 import System
-from PalmSens.Data import DeviceFile
+from PalmSens import Comm as PSComm
+from PalmSens import Data as PSData
+from PalmSens import Measurement as PSMeasurement
 
 from ..data import Measurement
 from .filesystem import DevicePath, FileSystemException
@@ -40,7 +41,7 @@ class DeviceFileSystemAsync:
             self.manager = instrument_or_manager
 
     @property
-    def _client_connection(self) -> PalmSens.Comm.ClientConnection:
+    def _client_connection(self) -> PSComm.ClientConnection:
         """The active client connection used for device communication."""
         return self.manager._comm.ClientConnection
 
@@ -66,7 +67,7 @@ class DeviceFileSystemAsync:
         """Join a path component to the root directory."""
         return self.root / path_str
 
-    async def _get_device_file(self, path: str | DevicePath) -> PalmSens.Data.DeviceFile:
+    async def _get_device_file(self, path: str | DevicePath) -> PSData.DeviceFile:
         """Retrieve the DeviceFile` for the given path."""
         if not isinstance(path, DevicePath):
             path = DevicePath(path)
@@ -80,7 +81,7 @@ class DeviceFileSystemAsync:
 
         async with self.manager._lock():
             try:
-                ret: PalmSens.Data.DeviceFile = await create_future(
+                ret: PSData.DeviceFile = await create_future(
                     self._client_connection.GetDeviceFileAsync(fspath)
                 )
             except System.Exception as exc:
@@ -93,7 +94,7 @@ class DeviceFileSystemAsync:
 
     async def _get_device_files(
         self, directory: DevicePath | str | None = None
-    ) -> list[DeviceFile]:
+    ) -> list[PSData.DeviceFile]:
         if not directory:
             directory = self.root
 
@@ -101,7 +102,7 @@ class DeviceFileSystemAsync:
             directory = DevicePath(directory)
 
         async with self.manager._lock():
-            ret: list[PalmSens.Data.DeviceFile] = await create_future(
+            ret: list[PSData.DeviceFile] = await create_future(
                 self._client_connection.GetDeviceFilesAsync(directory.__fspath__())
             )
 
@@ -162,7 +163,7 @@ class DeviceFileSystemAsync:
         f = await self._get_device_file(path)
 
         async with self.manager._lock():
-            psmeasurement: PalmSens.Measurement = await create_future(
+            psmeasurement: PSMeasurement = await create_future(
                 self._client_connection.LoadDeviceFileAsync(f)
             )
 

--- a/python/src/pypalmsens/_instruments/gpio.py
+++ b/python/src/pypalmsens/_instruments/gpio.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Literal, final
 
-import PalmSens
+from PalmSens import Comm as PSComm
 
 if TYPE_CHECKING:
     from .instrument_manager import InstrumentManager
@@ -29,11 +29,11 @@ def bitmask_to_pins(mask: int) -> list[int]:
     return [i for i in range(8) if (mask & (1 << i))]
 
 
-def is_methodscript(client_connection: PalmSens.Comm.ClientConnection) -> bool:
-    return isinstance(client_connection, PalmSens.Comm.ClientConnectionMS)
+def is_methodscript(client_connection: PSComm.ClientConnection) -> bool:
+    return isinstance(client_connection, PSComm.ClientConnectionMS)
 
 
-def writable_pins(client_connection: PalmSens.Comm.ClientConnection) -> list[int]:
+def writable_pins(client_connection: PSComm.ClientConnection) -> list[int]:
     """Return the pin numbers that support digital output.
 
     Return fixed pin numbers for the most common configuration for
@@ -45,7 +45,7 @@ def writable_pins(client_connection: PalmSens.Comm.ClientConnection) -> list[int
     return bitmask_to_pins(mask)
 
 
-def readable_pins(client_connection: PalmSens.Comm.ClientConnection) -> list[int]:
+def readable_pins(client_connection: PSComm.ClientConnection) -> list[int]:
     """Return the pin numbers that support digital input.
 
     Return fixed pin numbers for the most common configuration for
@@ -58,7 +58,7 @@ def readable_pins(client_connection: PalmSens.Comm.ClientConnection) -> list[int
 
 
 def raise_if_pins_not_supported(
-    client_connection: PalmSens.Comm.ClientConnection,
+    client_connection: PSComm.ClientConnection,
     pins: Sequence[int],
     mode: Literal['read', 'write'],
 ):
@@ -100,7 +100,7 @@ class GPIO:
 
     For explicit control, use the low-level MethodSCRIPT primitives directly:
 
-    - [pypalmsens.CommProtocol][]
+    - [pypSCommProtocol][]
     - [MethodSCRIPT manual](https://dev.palmsens.com/methodscript/latest/methodscript/methodscript_main.html)
     """
 

--- a/python/src/pypalmsens/_instruments/instrument.py
+++ b/python/src/pypalmsens/_instruments/instrument.py
@@ -6,9 +6,8 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
-import PalmSens
 import System
-from PalmSens.Comm import CommManager
+from PalmSens import Comm as PSComm
 from typing_extensions import override
 
 from .shared import create_future
@@ -36,7 +35,7 @@ class Instrument:
     Returns -1 if instrument is not part of a multichannel device."""
     interface: str
     """Type of the connection."""
-    device: PalmSens.Devices.Device = field(repr=False)
+    device: PSDevices.Device = field(repr=False)
     """Device connection class."""
 
     def __post_init__(self):
@@ -74,11 +73,11 @@ class Instrument:
         except System.NotSupportedException:
             self.device.Close()
 
-    async def _connect_async(self) -> CommManager:
+    async def _connect_async(self) -> PSComm.CommManager:
         """Open connection to instrument, return `CommManager` object."""
         device = await self._open_async()
 
-        return await create_future(CommManager.CommManagerAsync(device))
+        return await create_future(PSComm.CommManager.CommManagerAsync(device))
 
     @classmethod
     def from_port(cls, port: str, *, baudrate: int | None = None) -> Instrument:
@@ -126,7 +125,7 @@ class Instrument:
         return cls._from_device(device)
 
     @classmethod
-    def _from_device(cls, device: PalmSens.Devices.Device) -> Instrument:
+    def _from_device(cls, device: PSDevices.Device) -> Instrument:
         """Construct Instrument from PalmSens device connection class."""
         return cls(
             id=device.ToString(),
@@ -212,7 +211,7 @@ async def discover_async(
 
     for name, interface in interfaces.items():
         try:
-            devices: list[PalmSens.Devices.Device] = await create_future(
+            devices: list[PSDevices.Device] = await create_future(
                 interface.DiscoverDevicesAsync()
             )
         except System.DllNotFoundException:

--- a/python/src/pypalmsens/_instruments/measurement_manager_async.py
+++ b/python/src/pypalmsens/_instruments/measurement_manager_async.py
@@ -333,7 +333,7 @@ class MeasurementManagerAsync:
         pscurve.NewDataAdded -= self.event_handlers['curve_new_data']
         pscurve.Finished -= self.event_handlers['curve_end']
 
-        curve = Curve(pscurve=pscurve)
+        curve = Curve._wrap(pscurve)
 
         for callback in self.callbacks['curve_end']:
             _ = self.loop.call_soon_threadsafe(callback, curve)  # type: ignore
@@ -348,7 +348,7 @@ class MeasurementManagerAsync:
         pscurve.NewDataAdded += self.event_handlers['curve_new_data']
         pscurve.Finished += self.event_handlers['curve_end']
 
-        curve = Curve(pscurve=pscurve)
+        curve = Curve._wrap(pscurve)
 
         for callback in self.callbacks['curve_begin']:
             _ = self.loop.call_soon_threadsafe(callback, curve)  # type: ignore

--- a/python/src/pypalmsens/_instruments/measurement_manager_async.py
+++ b/python/src/pypalmsens/_instruments/measurement_manager_async.py
@@ -315,8 +315,8 @@ class MeasurementManagerAsync:
         """Called when new data is added to the curve."""
 
         data = CallbackData(
-            x_array=DataArray(psarray=pscurve.XAxisDataArray),
-            y_array=DataArray(psarray=pscurve.YAxisDataArray),
+            x_array=DataArray._wrap(pscurve.XAxisDataArray),
+            y_array=DataArray._wrap(pscurve.YAxisDataArray),
             start=args.StartIndex,
             id=pscurve.GetHashCode(),
         )

--- a/python/src/pypalmsens/_methods/levels.py
+++ b/python/src/pypalmsens/_methods/levels.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import field
 from typing import Literal
 
-import PalmSens
+from PalmSens import Techniques as PSTechniques
 
 from .._converters import single_to_double
 from .base_model import BaseModel
@@ -55,8 +55,8 @@ class ELevel(BaseModel):
 
         return use_limit_current_min or use_limit_current_max
 
-    def _to_psobj(self) -> PalmSens.Techniques.ELevel:
-        obj = PalmSens.Techniques.ELevel()
+    def _to_psobj(self) -> PSTechniques.ELevel:
+        obj = PSTechniques.ELevel()
 
         obj.Level = self.level
         obj.Duration = self.duration
@@ -76,7 +76,7 @@ class ELevel(BaseModel):
         return obj
 
     @classmethod
-    def _from_psobj(cls, psobj: PalmSens.Techniques.ELevel):
+    def _from_psobj(cls, psobj: PSTechniques.ELevel):
         """Construct ELevel dataclass from PalmSens.Techniques.ELevel object."""
         trigger_lines: list[Literal[0, 1, 2, 3]] = []
 
@@ -131,8 +131,8 @@ class ILevel(BaseModel):
 
         return use_limit_potential_min or use_limit_potential_max
 
-    def _to_psobj(self) -> PalmSens.Techniques.EILevel:
-        obj = PalmSens.Techniques.EILevel()
+    def _to_psobj(self) -> PSTechniques.EILevel:
+        obj = PSTechniques.EILevel()
 
         obj.Level = self.level
         obj.Duration = self.duration
@@ -152,7 +152,7 @@ class ILevel(BaseModel):
         return obj
 
     @classmethod
-    def _from_psobj(cls, psobj: PalmSens.Techniques.EILevel):
+    def _from_psobj(cls, psobj: PSTechniques.EILevel):
         """Construct ILevel dataclass from PalmSens.Techniques.ELevel object."""
         trigger_lines: list[Literal[0, 1, 2, 3]] = []
 

--- a/python/src/pypalmsens/_methods/mixed_mode.py
+++ b/python/src/pypalmsens/_methods/mixed_mode.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Annotated, ClassVar, Literal
 
 import PalmSens
+from PalmSens import Techniques as PSTechniques
 from pydantic import Field
 from typing_extensions import override
 
@@ -55,7 +56,7 @@ class BaseStage(BaseModel):
     def _export(self, psmethod: PalmSens.Method, /) -> PalmSens.Method:
         """Add stage to dotnet method, and update paramaters on dotnet stage."""
         stage_type = getattr(
-            PalmSens.Techniques.MixedMode.EnumMixedModeStageType,
+            PSTechniques.MixedMode.EnumMixedModeStageType,
             self.stage_type,  # type:ignore
         )
         psstage = psmethod.AddStage(stage_type)

--- a/python/src/pypalmsens/_methods/techniques.py
+++ b/python/src/pypalmsens/_methods/techniques.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Literal
 
 import PalmSens
+from PalmSens import Techniques as PSTechniques
 from PalmSens.Techniques.Impedance import enumFrequencyType, enumScanType
 from pydantic import Field, field_validator, model_validator
 from typing_extensions import Self, override
@@ -1065,7 +1066,7 @@ class PulsedAmperometricDetection(
         psmethod.RunTime = self.run_time
 
         mode = self._MODES.index(self.mode) + 1
-        psmethod.tMode = PalmSens.Techniques.PulsedAmpDetection.enumMode(mode)
+        psmethod.tMode = PSTechniques.PulsedAmpDetection.enumMode(mode)
 
     @override
     def _import(self, psmethod: PalmSens.Method, /):

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from math import isnan
 
 import numpy as np
-import PalmSens
 import pytest
+from PalmSens import Data as PSData
 
 from pypalmsens.data import CurrentArray, DataArray, PotentialArray
 
@@ -212,4 +212,29 @@ def test_constructor():
     assert arr.name == 'test'
     assert arr.type == 'Time'
     assert arr.unit == 's'
-    assert isinstance(arr._psarray, PalmSens.Data.DataArray)
+    assert isinstance(arr._psarray, PSData.DataArray)
+
+    c_arr = CurrentArray([1, 2, 3])
+    assert isinstance(c_arr._psarray, PSData.DataArrayCurrents)
+    assert c_arr.unit == 'µA'
+
+    p_arr = PotentialArray([1, 2, 3])
+    assert isinstance(p_arr._psarray, PSData.DataArrayPotentials)
+    assert p_arr.unit == 'V'
+
+    g_arr = DataArray([1, 2, 3])
+    assert g_arr.name == 'Generic'
+    assert g_arr.type == 'Generic'
+    assert g_arr.unit == 'Unknown'
+
+
+@pytest.mark.xfail(reason='Constructor does initialize values as CurrentReading')
+def test_constructor_current_reading_fail():
+    arr = CurrentArray([1, 2, 3])
+    _ = arr.current_reading()
+
+
+@pytest.mark.xfail(reason='Constructor does initialize values as PotentialReading')
+def test_constructor_potential_reading_fail():
+    arr = PotentialArray([1, 2, 3])
+    _ = arr.potential_reading()

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from math import isnan
 
 import numpy as np
+import PalmSens
 import pytest
 
-from pypalmsens.data import CurrentArray, PotentialArray
+from pypalmsens.data import CurrentArray, DataArray, PotentialArray
 
 
 @pytest.fixture
@@ -200,3 +201,15 @@ def test_potential_array(measurement_cv_1scan):
 
     d = arr.to_dict()
     assert len(d) == 5
+
+
+def test_constructor():
+    arr = DataArray([1.0, 2.0, 3.0], array_type='Time', name='test')
+
+    assert isinstance(arr, DataArray)
+    assert len(arr) == 3
+    assert arr.to_list() == [1.0, 2.0, 3.0]
+    assert arr.name == 'test'
+    assert arr.type == 'Time'
+    assert arr.unit == 's'
+    assert isinstance(arr._psarray, PalmSens.Data.DataArray)

--- a/python/tests/test_curve.py
+++ b/python/tests/test_curve.py
@@ -5,7 +5,7 @@ from math import isnan
 import numpy as np
 import pytest
 
-from pypalmsens.data import Curve
+from pypalmsens.data import CurrentArray, Curve, PotentialArray
 
 
 @pytest.fixture
@@ -195,3 +195,17 @@ def test_concat(curve_dpv):
     c = curve_dpv.concat(curve_dpv)
     assert len(c) == 2 * len(curve_dpv)
     assert c.n_points == 2 * curve_dpv.n_points
+
+
+def test_constructor():
+    current = CurrentArray([1, 2, 3])
+    potential = PotentialArray([1, 2, 3])
+    curve = Curve(current, potential, title='my curve')
+
+    assert curve.x_unit == 'µA'
+    assert curve.y_unit == 'V'
+    assert curve.title == 'my curve'
+    assert len(curve) == 3
+
+    assert isinstance(curve.x_array, CurrentArray)
+    assert isinstance(curve.y_array, PotentialArray)


### PR DESCRIPTION
This PR adds a pythonic constructor to the DataArray and Curve classes:

- `DataArray`:

```pycon
>>> ps.data.CurrentArray([1,2,3])
CurrentArray(name=Current, unit=µA, n_points=3)

>>> ps.data.PotentialArray([1,2,3])
PotentialArray(name=Potential, unit=V, n_points=3)

>>> ps.data.DataArray([1,2,3])
DataArray(name=Generic, unit=Unknown, n_points=3)

>>> ps.data.DataArray([1,2,3], array_type='Current')
DataArray(name=Current, unit=µA, n_points=3)

>>> ps.data.DataArray([1,2,3], array_type='Frequency')
DataArray(name=Frequency, unit=Hz, n_points=3)
```

- `Curve`:

```pycon
>>> current = ps.data.CurrentArray([1,2,3])
>>> potential = ps.data.PotentialArray([1,2,3])
>>> curve = ps.data.Curve(current, potential, title='my curve')
>>> curve
Curve(title=my curve, n_points=3)
```

### TODO

- [x] Documentation, needed?
- [x] Add tests for CurrentArray, PotentialArray
- [x] Follow-up: Apply the _wraps design to the other data classes, Dataset, EISData, Peak, Measurement, everything that takes a _psobject. #486 
- [x] Follow-up: Support units for ArrayType constructor