### PR TITLE
Update constructors for data wrappers

### DIFF
--- a/python/docs/zensical/reference/data.md
+++ b/python/docs/zensical/reference/data.md
@@ -6,7 +6,7 @@ from an expirement.
 
 These classes are wrappers for the underlying .NET code. Each Python
 wrapper in this module holds a reference to the underlying .NET SDK
-object, usually prefixed `ps...` like `Measurement.psmeasurement`.
+object in an attribute named `._internal` (e.g. `Measurement._internal`).
 These .NET classes are instantiated by the measurement or data loading
 code. These wrappers are intended to be used for data processing and
 exploration and not to be directly instantiated.

--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -37,12 +37,16 @@ class CurveMetadata:
 class Curve:
     __slots__ = ('_pscurve',)
 
-    """Python wrapper for .NET Curve class.
+    """Curve class with X and Y data of a single curve.
 
     Parameters
     ----------
-    pscurve
-        Reference to .NET curve object.
+    x : DataArray
+        Data values for the x axis
+    y : DataArray
+        Data values for the y axis
+    title : str, optional
+        Title for the curve
 
     Notes
     -----
@@ -174,7 +178,7 @@ class Curve:
             mergeOverlappingPeaks=merge_overlapping_peaks,
         )
 
-        peaks_list = [Peak(pspeak=peak) for peak in pspeaks]
+        peaks_list = [Peak._wrap(peak) for peak in pspeaks]
 
         return peaks_list
 
@@ -375,7 +379,7 @@ class Curve:
     def peaks(self) -> list[Peak]:
         """Return peaks stored on object."""
         try:
-            peaks = [Peak(pspeak=peak) for peak in self._pscurve.Peaks]
+            peaks = [Peak._wrap(peak) for peak in self._pscurve.Peaks]
         except TypeError:
             peaks = []
         return peaks

--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -35,8 +35,6 @@ class CurveMetadata:
 
 @final
 class Curve:
-    __slots__ = ('_pscurve',)
-
     """Curve class with X and Y data of a single curve.
 
     Parameters
@@ -54,13 +52,15 @@ class Curve:
     ``curve_a - curve_b`` return new curves.
     """
 
+    __slots__ = ('_internal',)
+
     def __init__(self, x: DataArray, y: DataArray, *, title: str = 'Curve'):
-        self._pscurve = PSCurve(x._psarray, y._psarray, title)
+        self._internal = PSCurve(x._internal, y._internal, title)
 
     @classmethod
     def _wrap(cls, pscurve: PSCurve) -> Self:
         obj = cls.__new__(cls)
-        obj._pscurve = pscurve
+        obj._internal = pscurve
         return obj
 
     def __add__(self, other: object) -> Self:
@@ -68,7 +68,7 @@ class Curve:
             return NotImplemented
 
         operator = PSMath.enumOperator.Add
-        new_curve = PSMath.AddSubtractCurves(self._pscurve, other._pscurve, operator)
+        new_curve = PSMath.AddSubtractCurves(self._internal, other._internal, operator)
 
         return type(self)._wrap(new_curve)
 
@@ -79,7 +79,7 @@ class Curve:
             return NotImplemented
 
         operator = PSMath.enumOperator.Subtract
-        new_curve = PSMath.AddSubtractCurves(self._pscurve, other._pscurve, operator)
+        new_curve = PSMath.AddSubtractCurves(self._internal, other._internal, operator)
 
         return type(self)._wrap(new_curve)
 
@@ -88,7 +88,7 @@ class Curve:
             return NotImplemented
 
         operator = PSMath.enumOperator.Subtract
-        new_curve = PSMath.AddSubtractCurves(other._pscurve, self._pscurve, operator)
+        new_curve = PSMath.AddSubtractCurves(other._internal, self._internal, operator)
 
         return type(self)._wrap(new_curve)
 
@@ -109,13 +109,13 @@ class Curve:
         Curve
             New curve with the concatenated x and y arrays.
         """
-        new_curve = PSMath.AppendCurves(self._pscurve, other._pscurve)
+        new_curve = PSMath.AppendCurves(self._internal, other._internal)
 
         return type(self)._wrap(new_curve)
 
     def copy(self) -> Curve:
         """Return a copy of this curve."""
-        return Curve._wrap(PSCurve(self._pscurve, cloneData=True))
+        return Curve._wrap(PSCurve(self._internal, cloneData=True))
 
     def smooth(self, smooth_level: int = 0):
         """Smooth the .y_array using a Savitsky-Golay filter with the specified smooth
@@ -127,7 +127,7 @@ class Curve:
             The smooth level to be used. -1 = none, 0 = no smooth (spike rejection only),
             1 = 5 points, 2 = 9 points, 3 = 15 points, 4 = 25 points
         """
-        success = self._pscurve.Smooth(smoothLevel=smooth_level)
+        success = self._internal.Smooth(smoothLevel=smooth_level)
         if not success:
             raise ValueError('Something went wrong.')
 
@@ -142,7 +142,7 @@ class Curve:
         window_size : int
             Size of the window
         """
-        self._pscurve.SavitskyGolay(windowSize=window_size)
+        self._internal.SavitskyGolay(windowSize=window_size)
 
     def find_peaks(
         self,
@@ -171,7 +171,7 @@ class Curve:
         -------
         peak_list : list[Peak]
         """
-        pspeaks = self._pscurve.FindPeaks(
+        pspeaks = self._internal.FindPeaks(
             minPeakWidth=min_peak_width,
             minPeakHeight=min_peak_height,
             peakShoulders=peak_shoulders,
@@ -206,7 +206,7 @@ class Curve:
         peak_list : list[Peak]
         """
         dct = System.Collections.Generic.Dictionary[PSCurve, System.Double]()
-        dct[self._pscurve] = min_peak_height
+        dct[self._internal] = min_peak_height
 
         pd = PSAnalysis.SemiDerivativePeakDetection()
         pd.GetNonOverlappingPeaks(dct)
@@ -261,11 +261,11 @@ class Curve:
             baseline: Curve
 
         _corrected = PSAnalysis.BaselineCorrection.GetMovingAverageBaselineCorrected(
-            self._pscurve, nWindowSize=window_size, maxNSweeps=max_sweeps, baseline=False
+            self._internal, nWindowSize=window_size, maxNSweeps=max_sweeps, baseline=False
         )
         _corrected.Title = self.title + ' (corrected)'
         _baseline = PSAnalysis.BaselineCorrection.GetMovingAverageBaselineCorrected(
-            self._pscurve, nWindowSize=window_size, maxNSweeps=max_sweeps, baseline=True
+            self._internal, nWindowSize=window_size, maxNSweeps=max_sweeps, baseline=True
         )
         _baseline.Title = self.title + ' (baseline)'
 
@@ -276,28 +276,28 @@ class Curve:
     @property
     def max_x(self) -> float:
         """Maximum X value found in this curve."""
-        return self._pscurve.MaxX
+        return self._internal.MaxX
 
     @property
     def max_y(self) -> float:
         """Maximum Y value found in this curve."""
-        return self._pscurve.MaxY
+        return self._internal.MaxY
 
     @property
     def min_x(self) -> float:
         """Minimum X value found in this curve."""
-        return self._pscurve.MinX
+        return self._internal.MinX
 
     @property
     def min_y(self) -> float:
         """Minimum Y value found in this curve."""
-        return self._pscurve.MinY
+        return self._internal.MinY
 
     @property
     def mux_channel(self) -> int:
         """The corresponding MUX channel number with the curve starting at 0.
         Return -1 when no MUX channel used."""
-        return self._pscurve.MuxChannel
+        return self._internal.MuxChannel
 
     @property
     def n_points(self) -> int:
@@ -305,61 +305,61 @@ class Curve:
         return len(self)
 
     def __len__(self):
-        return self._pscurve.NPoints
+        return self._internal.NPoints
 
     @property
     def ocp_value(self) -> float:
         """OCP value for curve."""
-        return self._pscurve.OCPValue
+        return self._internal.OCPValue
 
     @property
     def x_unit(self) -> str:
         """Units for X dimension."""
-        return self._pscurve.XUnit.ToString()
+        return self._internal.XUnit.ToString()
 
     @property
     def x_label(self) -> str:
         """Label for X dimension."""
-        return self._pscurve.XUnit.Quantity
+        return self._internal.XUnit.Quantity
 
     @property
     def y_unit(self) -> str:
         """Units for Y dimension."""
-        return self._pscurve.YUnit.ToString()
+        return self._internal.YUnit.ToString()
 
     @property
     def y_label(self) -> str:
         """Label for Y dimension."""
-        return self._pscurve.YUnit.Quantity
+        return self._internal.YUnit.Quantity
 
     @property
     def z_unit(self) -> None | str:
         """Units for Z dimension. Returns None if not set."""
-        if ret := self._pscurve.ZUnit:
+        if ret := self._internal.ZUnit:
             return ret.ToString()
         return None
 
     @property
     def z_label(self) -> None | str:
         """Units for Z dimension. Returns None if not set."""
-        if ret := self._pscurve.ZUnit:
+        if ret := self._internal.ZUnit:
             return ret.Quantity
         return None
 
     @property
     def title(self) -> str:
         """Title for the curve."""
-        return self._pscurve.Title
+        return self._internal.Title
 
     @title.setter
     def title(self, title: str):
         """Set the title for the curve."""
-        self._pscurve.Title = title
+        self._internal.Title = title
 
     @property
     def id(self) -> int:
         """Unique identifier for curve object."""
-        return self._pscurve.GetHashCode()
+        return self._internal.GetHashCode()
 
     def metadata(self) -> CurveMetadata:
         """Generate curve metadata as dataclass."""
@@ -379,24 +379,24 @@ class Curve:
     def peaks(self) -> list[Peak]:
         """Return peaks stored on object."""
         try:
-            peaks = [Peak._wrap(peak) for peak in self._pscurve.Peaks]
+            peaks = [Peak._wrap(peak) for peak in self._internal.Peaks]
         except TypeError:
             peaks = []
         return peaks
 
     def clear_peaks(self):
         """Clear peaks stored on object."""
-        self._pscurve.ClearPeaks()
+        self._internal.ClearPeaks()
 
     @property
     def x_array(self) -> DataArray:
         """Y data for the curve."""
-        return DataArray._wrap_dispatched(self._pscurve.XAxisDataArray)
+        return DataArray._wrap_dispatched(self._internal.XAxisDataArray)
 
     @property
     def y_array(self) -> DataArray:
         """Y data for the curve."""
-        return DataArray._wrap_dispatched(self._pscurve.YAxisDataArray)
+        return DataArray._wrap_dispatched(self._internal.YAxisDataArray)
 
     def linear_slope(
         self, start: None | int = None, stop: None | int = None
@@ -420,9 +420,9 @@ class Curve:
             Coefficient of determination (R2)
         """
         if start and stop:
-            return self._pscurve.LLS(start, stop)
+            return self._internal.LLS(start, stop)
         else:
-            return self._pscurve.LLS()
+            return self._internal.LLS()
 
     def plot(
         self,

--- a/python/src/pypalmsens/_data/data_array.py
+++ b/python/src/pypalmsens/_data/data_array.py
@@ -85,8 +85,8 @@ class DataArray(Sequence[float]):
     ``array_a * factor`` return new arrays.
     """
 
-    __slots__: ClassVar[tuple[str, ...]] = ('_psarray',)
-    _psarray: PSDataArray
+    __slots__: ClassVar[tuple[str, ...]] = ('_internal',)
+    _internal: PSDataArray
     _ps_cls: ClassVar[type[PSDataArray]] = PSDataArray
 
     def __init__(
@@ -115,12 +115,12 @@ class DataArray(Sequence[float]):
 
         new_array.AddRange(values)
 
-        self._psarray = new_array
+        self._internal = new_array
 
     @classmethod
     def _wrap(cls, psarray: PSDataArray) -> Self:
         obj = cls.__new__(cls)
-        obj._psarray = psarray
+        obj._internal = psarray
         return obj
 
     @classmethod
@@ -152,20 +152,20 @@ class DataArray(Sequence[float]):
             if index >= len(self) or index < -len(self):
                 raise IndexError('list index out of range')
             index = index % len(self)
-            return self._psarray[index].Value
+            return self._internal[index].Value
 
         return self.to_list()[index]
 
     @override
     def __len__(self) -> int:
-        return len(self._psarray)
+        return len(self._internal)
 
     def __add__(self, other: object) -> DataArray:
         if not isinstance(other, self.__class__):
             return NotImplemented
 
         operator = PSMath.enumOperator.Add
-        new_array = PSMath.AddSubtractDataArrays(self._psarray, other._psarray, operator)
+        new_array = PSMath.AddSubtractDataArrays(self._internal, other._internal, operator)
 
         return type(self)._wrap(new_array)
 
@@ -177,7 +177,7 @@ class DataArray(Sequence[float]):
             return NotImplemented
 
         operator = PSMath.enumOperator.Subtract
-        new_array = PSMath.AddSubtractDataArrays(self._psarray, other._psarray, operator)
+        new_array = PSMath.AddSubtractDataArrays(self._internal, other._internal, operator)
 
         return type(self)._wrap(new_array)
 
@@ -186,7 +186,7 @@ class DataArray(Sequence[float]):
             return NotImplemented
 
         operator = PSMath.enumOperator.Subtract
-        new_array = PSMath.AddSubtractDataArrays(other._psarray, self._psarray, operator)
+        new_array = PSMath.AddSubtractDataArrays(other._internal, self._internal, operator)
 
         return type(self)._wrap(new_array)
 
@@ -194,10 +194,10 @@ class DataArray(Sequence[float]):
         if not isinstance(value, (int, float)):
             return NotImplemented
 
-        new_values = PSMath.MultiplyDataArray(self._psarray.GetValues(), value)
+        new_values = PSMath.MultiplyDataArray(self._internal.GetValues(), value)
 
         new_array = PSDataArray(
-            self._psarray.Description, self._psarray.Unit, self._psarray.ArrayType
+            self._internal.Description, self._internal.Unit, self._internal.ArrayType
         )
         new_array.AddRange(new_values)
 
@@ -219,24 +219,24 @@ class DataArray(Sequence[float]):
         new_array : DataArray
             Data array with normalized values.
         """
-        new_values = PSMath.NormalizeArray(self._psarray.GetValues(), self.min(), self.max())
+        new_values = PSMath.NormalizeArray(self._internal.GetValues(), self.min(), self.max())
         new_array = PSDataArray(
-            self._psarray.Description, self._psarray.Unit, self._psarray.ArrayType
+            self._internal.Description, self._internal.Unit, self._internal.ArrayType
         )
         new_array.AddRange(new_values)
         return type(self)._wrap(new_array)
 
     def copy(self) -> DataArray:
         """Return a copy of the array."""
-        return DataArray._wrap(self._psarray.Clone())
+        return DataArray._wrap(self._internal.Clone())
 
     def min(self) -> float:
         """Return min value."""
-        return self._psarray.MinValue
+        return self._internal.MinValue
 
     def max(self) -> float:
         """Return max value."""
-        return self._psarray.MaxValue
+        return self._internal.MaxValue
 
     def savitsky_golay(self, window_size: int = 3) -> DataArray:
         """Smooth the array using a Savitsky-Golay filter with the window size.
@@ -249,7 +249,7 @@ class DataArray(Sequence[float]):
             Size of the window
         """
         new = self.copy()
-        success = new._psarray.Smooth(window_size, False)
+        success = new._internal.Smooth(window_size, False)
         if not success:
             raise ValueError('Something went wrong.')
         return new
@@ -257,35 +257,35 @@ class DataArray(Sequence[float]):
     @property
     def name(self) -> str:
         """Name of the array."""
-        return self._psarray.Description
+        return self._internal.Description
 
     def to_numpy(self) -> np.ndarray:
         """Export data array to numpy."""
-        return np.array(self._psarray.GetValues())
+        return np.array(self._internal.GetValues())
 
     def to_list(self) -> list[float]:
         """Export data array to list."""
-        return list(self._psarray.GetValues())
+        return list(self._internal.GetValues())
 
     @property
     def type(self) -> AllowedArrayTypes:
         """Array type as str."""
-        return array_enum_to_str(self._psarray.ArrayType)
+        return array_enum_to_str(self._internal.ArrayType)
 
     @property
     def unit(self) -> str:
         """Unit for array."""
-        return self._psarray.Unit.ToString()
+        return self._internal.Unit.ToString()
 
     @property
     def quantity(self) -> str:
         """Quantity for array."""
-        return self._psarray.Unit.Quantity
+        return self._internal.Unit.Quantity
 
     @property
     def ocp_value(self) -> float:
         """OCP Value."""
-        return self._psarray.OCPValue
+        return self._internal.OCPValue
 
     @property
     def is_derived(self) -> bool:
@@ -331,7 +331,7 @@ class CurrentArray(DataArray):
         """Current in µA."""
         # Work-around for mIDC bug
         if self.type == 'miDC':
-            return [implementation(val).Value for val in self._psarray]
+            return [implementation(val).Value for val in self._internal]
         return self.to_list()
 
     def current_in_range(self) -> list[float]:
@@ -339,23 +339,23 @@ class CurrentArray(DataArray):
 
         `current` = `current_in_range` * CR, e.g. 0.2 * 100uA = 2.0 uA
         """
-        return [implementation(val).ValueInRange for val in self._psarray]
+        return [implementation(val).ValueInRange for val in self._internal]
 
     def current_reading(self) -> list[CurrentReading]:
         """Return as list of potential reading objects."""
-        return [CurrentReading._from_psobject(implementation(val)) for val in self._psarray]
+        return [CurrentReading._from_psobject(implementation(val)) for val in self._internal]
 
     def current_range(self) -> list[AllowedCurrentRanges]:
         """Return current range as list of strings."""
-        return [cr_enum_to_string(implementation(val).CurrentRange) for val in self._psarray]
+        return [cr_enum_to_string(implementation(val).CurrentRange) for val in self._internal]
 
     def reading_status(self) -> list[AllowedReadingStatus]:
         """Return reading status as list of strings."""
-        return [str(implementation(val).ReadingStatus) for val in self._psarray]  # type:ignore
+        return [str(implementation(val).ReadingStatus) for val in self._internal]  # type:ignore
 
     def timing_status(self) -> list[AllowedTimingStatus]:
         """Return timing status as list of strings."""
-        return [str(implementation(val).TimingStatus) for val in self._psarray]  # type:ignore
+        return [str(implementation(val).TimingStatus) for val in self._internal]  # type:ignore
 
     def to_dict(self) -> dict[str, list[Any]]:
         """Return array as key/value mapping.
@@ -434,23 +434,23 @@ class PotentialArray(DataArray):
 
         `potential` = `potential_in_range` * PR, e.g. 2.0 * 100mV = 0.2V
         """
-        return [implementation(val).ValueInRange for val in self._psarray]
+        return [implementation(val).ValueInRange for val in self._internal]
 
     def potential_reading(self) -> list[PotentialReading]:
         """Return as list of potential reading objects."""
-        return [PotentialReading._from_psobject(implementation(val)) for val in self._psarray]
+        return [PotentialReading._from_psobject(implementation(val)) for val in self._internal]
 
     def potential_range(self) -> list[AllowedPotentialRanges]:
         """Return potential range as list of strings."""
-        return [pr_enum_to_string(implementation(val).Range) for val in self._psarray]
+        return [pr_enum_to_string(implementation(val).Range) for val in self._internal]
 
     def reading_status(self) -> list[AllowedReadingStatus]:
         """Return reading status as list of strings."""
-        return [str(implementation(val).ReadingStatus) for val in self._psarray]  # type:ignore
+        return [str(implementation(val).ReadingStatus) for val in self._internal]  # type:ignore
 
     def timing_status(self) -> list[AllowedTimingStatus]:
         """Return timing status as list of strings."""
-        return [str(implementation(val).TimingStatus) for val in self._psarray]  # type:ignore
+        return [str(implementation(val).TimingStatus) for val in self._internal]  # type:ignore
 
     def to_dict(self) -> dict[str, list[Any]]:
         """Return array as key/value mapping.

--- a/python/src/pypalmsens/_data/dataset.py
+++ b/python/src/pypalmsens/_data/dataset.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Self, final
 
-from PalmSens.Plottables import Curve as PSCurve
 from typing_extensions import override
 
 from .curve import Curve
@@ -42,7 +41,10 @@ def _dataset_to_mapping_with_unique_keys(psdataset: PSDataSet, /) -> dict[str, D
 
 @final
 class DataSet(Mapping[str, DataArray]):
-    """Dataset containing measurement data.
+    """Dataset containing multiple data arrays.
+
+    All values are related by means of their indices.
+    DataArrays in a DataSet should always have an equal amount of entries.
 
     Notes
     -----
@@ -50,8 +52,8 @@ class DataSet(Mapping[str, DataArray]):
     Obtain internal instances via `_wrap`.
     """
 
-    __slots__: ClassVar[tuple[str, ...]] = ('_mapping', '_psdataset')
-    _psdataset: PSDataSet  # pyright: ignore[reportUninitializedInstanceVariable]
+    __slots__: ClassVar[tuple[str, ...]] = ('_internal', '_mapping')
+    _internal: PSDataSet  # pyright: ignore[reportUninitializedInstanceVariable]
     _mapping: dict[str, DataArray]  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def __init__(self):
@@ -63,7 +65,7 @@ class DataSet(Mapping[str, DataArray]):
     @classmethod
     def _wrap(cls, psdataset: PSDataSet) -> Self:
         obj = cls.__new__(cls)
-        obj._psdataset = psdataset
+        obj._internal = psdataset
         obj._mapping = _dataset_to_mapping_with_unique_keys(psdataset)
         return obj
 
@@ -92,14 +94,10 @@ class DataSet(Mapping[str, DataArray]):
         """
         return [array for array in self._mapping.values() if key(array)]
 
-    def _psarrays(self):
-        """Return underlying PalmSens SDK objects."""
-        return self._psdataset.GetDataArrays()
-
     @property
     def n_points(self) -> int:
         """Number of points in arrays."""
-        return self._psdataset.NPoints
+        return self._internal.NPoints
 
     def curve(self, x: str, y: str, title: str | None = None) -> Curve:
         """Construct a custom curve from x and y keys.
@@ -124,9 +122,7 @@ class DataSet(Mapping[str, DataArray]):
         if not title:
             title = f'{x}-{y}'
 
-        pscurve = PSCurve(xarray._psarray, yarray._psarray, title=title)
-
-        return Curve._wrap(pscurve)
+        return Curve(xarray, yarray, title=title)
 
     def arrays(
         self,
@@ -166,7 +162,7 @@ class DataSet(Mapping[str, DataArray]):
         elif quantity:
             return self._filter(key=lambda array: array.quantity == quantity)
         elif hidden:
-            return [DataArray._wrap(psarray) for psarray in self._psdataset if psarray.Hidden]
+            return [DataArray._wrap(psarray) for psarray in self._internal if psarray.Hidden]
         else:
             return list(self.values())
 

--- a/python/src/pypalmsens/_data/dataset.py
+++ b/python/src/pypalmsens/_data/dataset.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, final
+from typing import TYPE_CHECKING, Any, ClassVar, Self, final
 
 from PalmSens.Plottables import Curve as PSCurve
 from typing_extensions import override
@@ -42,17 +42,31 @@ def _dataset_to_mapping_with_unique_keys(psdataset: PSDataSet, /) -> dict[str, D
 
 @final
 class DataSet(Mapping[str, DataArray]):
-    """Python wrapper for .NET DataSet class.
+    """Dataset containing measurement data.
 
-    Parameters
-    ----------
-    psdataset : PalmSens.Data.DataSet
-        Reference to .NET DataSet object.
+    Notes
+    -----
+    `__init__` is currently reserved for a future public API.
+    Obtain internal instances via `_wrap`.
     """
 
-    def __init__(self, *, psdataset: PSDataSet):
-        self._psdataset = psdataset
-        self._mapping = _dataset_to_mapping_with_unique_keys(psdataset)
+    __slots__: ClassVar[tuple[str, ...]] = ('_mapping', '_psdataset')
+
+    def __init__(self):
+        self._psdataset: PSDataSet
+        self._mapping: dict[str, DataArray]
+
+        raise TypeError(
+            'DataSet cannot be instantiated directly. '
+            'Obtain instances through measurements or io methods.'
+        )
+
+    @classmethod
+    def _wrap(cls, psdataset: PSDataSet) -> Self:
+        obj = cls.__new__(cls)
+        obj._psdataset = psdataset
+        obj._mapping = _dataset_to_mapping_with_unique_keys(psdataset)
+        return obj
 
     @override
     def __repr__(self):

--- a/python/src/pypalmsens/_data/dataset.py
+++ b/python/src/pypalmsens/_data/dataset.py
@@ -51,11 +51,10 @@ class DataSet(Mapping[str, DataArray]):
     """
 
     __slots__: ClassVar[tuple[str, ...]] = ('_mapping', '_psdataset')
+    _psdataset: PSDataSet  # pyright: ignore[reportUninitializedInstanceVariable]
+    _mapping: dict[str, DataArray]  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def __init__(self):
-        self._psdataset: PSDataSet
-        self._mapping: dict[str, DataArray]
-
         raise TypeError(
             'DataSet cannot be instantiated directly. '
             'Obtain instances through measurements or io methods.'

--- a/python/src/pypalmsens/_data/eisdata.py
+++ b/python/src/pypalmsens/_data/eisdata.py
@@ -46,8 +46,8 @@ class EISData:
     Obtain internal instances via `_wrap`.
     """
 
-    __slots__: ClassVar[tuple[str, ...]] = ('_pseis',)
-    _pseis: PSEISData  # pyright: ignore[reportUninitializedInstanceVariable]
+    __slots__: ClassVar[tuple[str, ...]] = ('_internal',)
+    _internal: PSEISData  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def __init__(self):
         raise TypeError(
@@ -58,7 +58,7 @@ class EISData:
     @classmethod
     def _wrap(cls, pseis: PSEISData) -> Self:
         obj = cls.__new__(cls)
-        obj._pseis = pseis
+        obj._internal = pseis
         return obj
 
     @override
@@ -77,69 +77,69 @@ class EISData:
     @property
     def title(self) -> str:
         """Tite for EIS data."""
-        return self._pseis.Title
+        return self._internal.Title
 
     @property
     def frequency_type(self) -> AllowedFrequencyTypes:
         """Frequency type."""
-        return str(self._pseis.FreqType).lower()  # type: ignore
+        return str(self._internal.FreqType).lower()  # type: ignore
 
     @property
     def scan_type(self) -> AllowedScanTypes:
         """Scan type."""
-        value = str(self._pseis.ScanType)
+        value = str(self._internal.ScanType)
         mapping = {'TimeScan': 'time', 'PGScan': 'potential', 'Fixed': 'fixed'}
         return mapping[value]  # type: ignore
 
     @property
     def dataset(self) -> DataSet:
         """Dataset which contains multiple arrays of values."""
-        return DataSet._wrap(self._pseis.EISDataSet)
+        return DataSet._wrap(self._internal.EISDataSet)
 
     @property
     def subscans(self) -> list[EISData]:
         """Get list of subscans."""
-        return [EISData._wrap(subscan) for subscan in self._pseis.GetSubScans()]
+        return [EISData._wrap(subscan) for subscan in self._internal.GetSubScans()]
 
     @property
     def n_points(self) -> int:
         """Number of points (including subscans)."""
-        return self._pseis.NPoints
+        return self._internal.NPoints
 
     @property
     def n_frequencies(self) -> int:
         """Number of frequencies."""
-        return self._pseis.NFrequencies
+        return self._internal.NFrequencies
 
     @property
     def n_subscans(self) -> int:
         """Number of subscans."""
-        return len(self._pseis.GetSubScans())
+        return len(self._internal.GetSubScans())
 
     @property
     def x_unit(self) -> str:
         """Unit for array."""
-        return self._pseis.XUnit.ToString()
+        return self._internal.XUnit.ToString()
 
     @property
     def x_quantity(self) -> str:
         """Quantity for array."""
-        return self._pseis.XUnit.Quantity
+        return self._internal.XUnit.Quantity
 
     @property
     def ocp_value(self) -> float:
         """OCP Value."""
-        return self._pseis.OCPValue
+        return self._internal.OCPValue
 
     @property
     def has_subscans(self) -> bool:
         """Return True if data contains subscans."""
-        return self._pseis.HasSubScans
+        return self._internal.HasSubScans
 
     @property
     def mux_channel(self) -> int:
         """Mux channel."""
-        return self._pseis.MuxChannel
+        return self._internal.MuxChannel
 
     def get_data_for_frequency(self, frequency: int) -> dict[str, DataArray]:
         """Returns dictionary with data per frequency.
@@ -159,7 +159,7 @@ class EISData:
 
         return {
             str(row.Key): DataArray._wrap(row.Value)
-            for row in self._pseis.GetDataArrayVsX(frequency)
+            for row in self._internal.GetDataArrayVsX(frequency)
         }
 
     def arrays(self) -> list[DataArray]:
@@ -169,23 +169,24 @@ class EISData:
     def current_range(self) -> list[AllowedCurrentRanges]:
         """Current ranges for the measurement."""
         return [
-            cr_enum_to_string(self._pseis.GetCurrentRange(val)) for val in range(self.n_points)
+            cr_enum_to_string(self._internal.GetCurrentRange(val))
+            for val in range(self.n_points)
         ]
 
     @property
     def cdc(self) -> str:
         """Gets the CDC circuit for fitting."""
-        return self._pseis.CDC
+        return self._internal.CDC
 
     @property
     def cdc_values(self) -> list[float]:
         """Return values for circuit description code (CDC)."""
-        return list(self._pseis.CDCValues)
+        return list(self._internal.CDCValues)
 
     @property
     def id(self) -> int:
         """Unique identifier for curve object."""
-        return self._pseis.GetHashCode()
+        return self._internal.GetHashCode()
 
     def metadata(self) -> EISDataMetadata:
         """Return eis data metadata as dataclass"""

--- a/python/src/pypalmsens/_data/eisdata.py
+++ b/python/src/pypalmsens/_data/eisdata.py
@@ -83,7 +83,7 @@ class EISData:
     @property
     def dataset(self) -> DataSet:
         """Dataset which contains multiple arrays of values."""
-        return DataSet(psdataset=self._pseis.EISDataSet)
+        return DataSet._wrap(self._pseis.EISDataSet)
 
     @property
     def subscans(self) -> list[EISData]:

--- a/python/src/pypalmsens/_data/eisdata.py
+++ b/python/src/pypalmsens/_data/eisdata.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, final
+from typing import TYPE_CHECKING, ClassVar, Literal, Self, final
 
 from pydantic import TypeAdapter
 from pydantic.dataclasses import dataclass as pydantic_dataclass
@@ -39,16 +39,27 @@ class EISDataMetadata:
 
 @final
 class EISData:
-    """Python wrapper for .NET EISdata class.
+    """Dataset containing impedance measurement results.
 
-    Parameters
-    ----------
-    pseis
-        Reference to .NET EISdata object.
+    Notes
+    -----
+    Obtain internal instances via `_wrap`.
     """
 
-    def __init__(self, *, pseis: PSEISData):
-        self._pseis = pseis
+    __slots__: ClassVar[tuple[str, ...]] = ('_pseis',)
+    _pseis: PSEISData  # pyright: ignore[reportUninitializedInstanceVariable]
+
+    def __init__(self):
+        raise TypeError(
+            'EISData cannot be instantiated directly. '
+            'Obtain instances through measurements or io methods.'
+        )
+
+    @classmethod
+    def _wrap(cls, pseis: PSEISData) -> Self:
+        obj = cls.__new__(cls)
+        obj._pseis = pseis
+        return obj
 
     @override
     def __repr__(self):
@@ -88,7 +99,7 @@ class EISData:
     @property
     def subscans(self) -> list[EISData]:
         """Get list of subscans."""
-        return [EISData(pseis=subscan) for subscan in self._pseis.GetSubScans()]
+        return [EISData._wrap(subscan) for subscan in self._pseis.GetSubScans()]
 
     @property
     def n_points(self) -> int:

--- a/python/src/pypalmsens/_data/measurement.py
+++ b/python/src/pypalmsens/_data/measurement.py
@@ -165,7 +165,7 @@ class Measurement:
     @property
     def eis_data(self) -> list[EISData]:
         """EIS data in measurement."""
-        lst = [EISData(pseis=pseis) for pseis in self._psmeasurement.EISdata]
+        lst = [EISData._wrap(pseis) for pseis in self._psmeasurement.EISdata]
 
         return lst
 

--- a/python/src/pypalmsens/_data/measurement.py
+++ b/python/src/pypalmsens/_data/measurement.py
@@ -76,8 +76,8 @@ class Measurement:
     Obtain internal instances via `_wrap`.
     """
 
-    __slots__: ClassVar[tuple[str, ...]] = ('_psmeasurement',)
-    _psmeasurement: PSMeasurement  # pyright: ignore[reportUninitializedInstanceVariable]
+    __slots__: ClassVar[tuple[str, ...]] = ('_internal',)
+    _internal: PSMeasurement  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def __init__(self):
 
@@ -89,7 +89,7 @@ class Measurement:
     @classmethod
     def _wrap(cls, psmeasurement: PSMeasurement) -> Self:
         obj = cls.__new__(cls)
-        obj._psmeasurement = psmeasurement
+        obj._internal = psmeasurement
         return obj
 
     @override
@@ -99,7 +99,7 @@ class Measurement:
     @property
     def title(self) -> str:
         """Title for the measurement."""
-        return self._psmeasurement.Title
+        return self._internal.Title
 
     @property
     def timestamp(self) -> datetime:
@@ -108,7 +108,7 @@ class Measurement:
         Returns a timezone-naive `datetime` in local time, matching the format
         used by the SDK (e.g. ``2017-07-12 14:28:58``).
         """
-        timestamp = self._psmeasurement.TimeStamp
+        timestamp = self._internal.TimeStamp
         return datetime.fromisoformat(
             timestamp.ToString('s', System.Globalization.CultureInfo.InvariantCulture)
         )
@@ -116,7 +116,7 @@ class Measurement:
     @property
     def device(self) -> DeviceInfo:
         """Return dataclass with measurement device information."""
-        return DeviceInfo._from_psmeasurement(self._psmeasurement)
+        return DeviceInfo._from_psmeasurement(self._internal)
 
     def metadata(self) -> MeasurementMetadata:
         """Return measurement metadata as dataclass"""
@@ -138,7 +138,7 @@ class Measurement:
         if Blank curve is present (not null) a new curve will be added after each measurement
         containing the result of the measured curve subtracted with the Blank curve.
         """
-        curve = self._psmeasurement.BlankCurve
+        curve = self._internal.BlankCurve
         if curve:
             return Curve._wrap(curve)
         return None
@@ -146,12 +146,12 @@ class Measurement:
     @property
     def has_blank_subtracted_curves(self) -> bool:
         """Return True if the curve collection contains a blank subtracted curve."""
-        return self._psmeasurement.ContainsBlankSubtractedCurves
+        return self._internal.ContainsBlankSubtractedCurves
 
     @property
     def has_eis_data(self) -> bool:
         """Return True if EIS data are is available."""
-        return self._psmeasurement.ContainsEISdata
+        return self._internal.ContainsEISdata
 
     @property
     def dataset(self) -> DataSet:
@@ -160,12 +160,12 @@ class Measurement:
         All values are related by means of their indices.
         Data arrays in a dataset should always have an equal amount of entries.
         """
-        return DataSet._wrap(self._psmeasurement.DataSet)
+        return DataSet._wrap(self._internal.DataSet)
 
     @property
     def eis_data(self) -> list[EISData]:
         """EIS data in measurement."""
-        lst = [EISData._wrap(pseis) for pseis in self._psmeasurement.EISdata]
+        lst = [EISData._wrap(pseis) for pseis in self._internal.EISdata]
 
         return lst
 
@@ -174,27 +174,27 @@ class Measurement:
         """Method related with this Measurement.
 
         The information from the Method is used when saving Curves."""
-        return Method._wrap(self._psmeasurement.Method).to_settings()
+        return Method._wrap(self._internal.Method).to_settings()
 
     @property
     def channel(self) -> float:
         """Get the channel that the measurement was measured on."""
-        return self._psmeasurement.Channel
+        return self._internal.Channel
 
     @property
     def ocp_value(self) -> float:
         """First OCP Value from either curves or EISData."""
-        return self._psmeasurement.OcpValue
+        return self._internal.OcpValue
 
     @property
     def n_curves(self) -> int:
         """Number of curves that are part of the Measurement class."""
-        return self._psmeasurement.nCurves
+        return self._internal.nCurves
 
     @property
     def n_eis_data(self) -> int:
         """Number of EISdata curves (channels) that are part of the Measurement class."""
-        return self._psmeasurement.nEISdata
+        return self._internal.nEISdata
 
     @property
     def peaks(self) -> list[Peak]:
@@ -232,4 +232,4 @@ class Measurement:
         curves : list[Curve]
             List of curves
         """
-        return [Curve._wrap(curve) for curve in self._psmeasurement.GetCurveArray()]
+        return [Curve._wrap(curve) for curve in self._internal.GetCurveArray()]

--- a/python/src/pypalmsens/_data/measurement.py
+++ b/python/src/pypalmsens/_data/measurement.py
@@ -77,9 +77,9 @@ class Measurement:
     """
 
     __slots__: ClassVar[tuple[str, ...]] = ('_psmeasurement',)
+    _psmeasurement: PSMeasurement  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def __init__(self):
-        self._psmeasurement: PSMeasurement
 
         raise TypeError(
             'Measurement cannot be instantiated directly. '

--- a/python/src/pypalmsens/_data/measurement.py
+++ b/python/src/pypalmsens/_data/measurement.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Literal, final
+from typing import TYPE_CHECKING, ClassVar, Literal, Self, final
 
 import System
 from pydantic import TypeAdapter
@@ -68,16 +68,29 @@ class MeasurementMetadata:
 
 @final
 class Measurement:
-    """Python wrapper for .NET Measurement class.
+    """Measurement class containing method parameters, curves, and raw data.
 
-    Parameters
-    ----------
-    psmeasurement
-        Reference to .NET measurement object.
+    Notes
+    -----
+    `__init__` is currently reserved for a future public API.
+    Obtain internal instances via `_wrap`.
     """
 
-    def __init__(self, *, psmeasurement: PSMeasurement):
-        self._psmeasurement = psmeasurement
+    __slots__: ClassVar[tuple[str, ...]] = ('_psmeasurement',)
+
+    def __init__(self):
+        self._psmeasurement: PSMeasurement
+
+        raise TypeError(
+            'Measurement cannot be instantiated directly. '
+            'Obtain instances through measurements or io methods.'
+        )
+
+    @classmethod
+    def _wrap(cls, psmeasurement: PSMeasurement) -> Self:
+        obj = cls.__new__(cls)
+        obj._psmeasurement = psmeasurement
+        return obj
 
     @override
     def __repr__(self):
@@ -147,7 +160,7 @@ class Measurement:
         All values are related by means of their indices.
         Data arrays in a dataset should always have an equal amount of entries.
         """
-        return DataSet(psdataset=self._psmeasurement.DataSet)
+        return DataSet._wrap(self._psmeasurement.DataSet)
 
     @property
     def eis_data(self) -> list[EISData]:
@@ -161,7 +174,7 @@ class Measurement:
         """Method related with this Measurement.
 
         The information from the Method is used when saving Curves."""
-        return Method(psmethod=self._psmeasurement.Method).to_settings()
+        return Method._wrap(self._psmeasurement.Method).to_settings()
 
     @property
     def channel(self) -> float:

--- a/python/src/pypalmsens/_data/method.py
+++ b/python/src/pypalmsens/_data/method.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar, Self
 
 import PalmSens
 
@@ -11,10 +11,28 @@ from .._methods.techniques import BaseTechnique
 
 
 class Method:
-    """Wrapper for PalmSens.Method."""
+    """Wrapper for PalmSens.Method.
 
-    def __init__(self, *, psmethod: PalmSens.Method):
-        self._psmethod = psmethod
+    Notes
+    -----
+    Obtain internal instances via `_wrap`.
+    """
+
+    __slots__: ClassVar[tuple[str, ...]] = ('_psmethod',)
+
+    def __init__(self):
+        self._psmethod: PalmSens.Method
+
+        raise TypeError(
+            'Method cannot be instantiated directly. '
+            'Obtain instances through the Technique methods.'
+        )
+
+    @classmethod
+    def _wrap(cls, psmethod: PalmSens.Method) -> Self:
+        obj = cls.__new__(cls)
+        obj._psmethod = psmethod
+        return obj
 
     def __repr__(self) -> str:
         return f'{type(self).__name__}(name={self.name!r}, id={self.id!r})'

--- a/python/src/pypalmsens/_data/method.py
+++ b/python/src/pypalmsens/_data/method.py
@@ -18,8 +18,8 @@ class Method:
     Obtain internal instances via `_wrap`.
     """
 
-    __slots__: ClassVar[tuple[str, ...]] = ('_psmethod',)
-    _psmethod: PalmSens.Method  # pyright: ignore[reportUninitializedInstanceVariable]
+    __slots__: ClassVar[tuple[str, ...]] = ('_internal',)
+    _internal: PalmSens.Method  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def __init__(self):
         raise TypeError(
@@ -30,7 +30,7 @@ class Method:
     @classmethod
     def _wrap(cls, psmethod: PalmSens.Method) -> Self:
         obj = cls.__new__(cls)
-        obj._psmethod = psmethod
+        obj._internal = psmethod
         return obj
 
     def __repr__(self) -> str:
@@ -39,22 +39,22 @@ class Method:
     @property
     def id(self) -> str:
         """Unique id for method."""
-        return self._psmethod.MethodID
+        return self._internal.MethodID
 
     @property
     def name(self) -> str:
         """Name for the technique."""
-        return self._psmethod.Name
+        return self._internal.Name
 
     @property
     def short_name(self) -> str:
         """Short name for the technique."""
-        return self._psmethod.ShortName
+        return self._internal.ShortName
 
     @property
     def filename(self) -> Path | None:
         """Filename for the method if applicable."""
-        fn = self._psmethod.MethodFilename
+        fn = self._internal.MethodFilename
         if fn:
             return Path(fn)
         return None
@@ -62,16 +62,16 @@ class Method:
     @property
     def supports_corrosion(self) -> bool:
         """Return true if corrosion is supported."""
-        return self._psmethod.SupportsCorrosion
+        return self._internal.SupportsCorrosion
 
     @property
     def technique_number(self) -> int:
         """The technique number used in the firmware."""
-        return self._psmethod.Technique
+        return self._internal.Technique
 
     def to_settings(self) -> MethodType:
         """Extract techniques parameters as dataclass."""
-        return BaseTechnique._from_psmethod(self._psmethod)
+        return BaseTechnique._from_psmethod(self._internal)
 
     def to_dict(self) -> dict[str, Any]:
         """Return dictionary with technique parameters."""

--- a/python/src/pypalmsens/_data/method.py
+++ b/python/src/pypalmsens/_data/method.py
@@ -19,10 +19,9 @@ class Method:
     """
 
     __slots__: ClassVar[tuple[str, ...]] = ('_psmethod',)
+    _psmethod: PalmSens.Method  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def __init__(self):
-        self._psmethod: PalmSens.Method
-
         raise TypeError(
             'Method cannot be instantiated directly. '
             'Obtain instances through the Technique methods.'

--- a/python/src/pypalmsens/_data/peak.py
+++ b/python/src/pypalmsens/_data/peak.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, ClassVar, Self, final
 
 from typing_extensions import override
 
@@ -14,18 +14,27 @@ if TYPE_CHECKING:
 
 @final
 class Peak:
-    """Python wrapper for .NET Peak class.
+    """Contains the peak data of one peak in a curve.
 
-    Parameters
-    ----------
-    pspeak : PalmSens.Analysis.Peak
-        Reference to .NET Peak object.
+    Notes
+    -----
+    Obtain internal instances via `_wrap`.
     """
 
-    def __init__(self, *, pspeak: PSPeak):
-        self._pspeak = pspeak
+    __slots__: ClassVar[tuple[str, ...]] = ('_pspeak',)
 
-        self._curve: Curve | None = None
+    def __init__(self):
+        self._pspeak: PSPeak
+
+        raise TypeError(
+            'Peak cannot be instantiated directly. Obtain instances through the Curve methods.'
+        )
+
+    @classmethod
+    def _wrap(cls, pspeak: PSPeak) -> Self:
+        obj = cls.__new__(cls)
+        obj._pspeak = pspeak
+        return obj
 
     @override
     def __repr__(self):
@@ -46,24 +55,7 @@ class Peak:
         """Parent curve associated with Peak."""
         from .curve import Curve
 
-        if not self._curve:
-            self._curve = Curve._wrap(self._pspeak.Curve)
-        return self._curve
-
-    @property
-    def curve_title(self) -> str:
-        """Title of parent curve."""
-        return self.curve.title
-
-    @property
-    def x_unit(self) -> str:
-        """Units of X axis."""
-        return self.curve.x_unit
-
-    @property
-    def y_unit(self) -> str:
-        """Units for Y axis."""
-        return self.curve.y_unit
+        return Curve._wrap(self._pspeak.Curve)
 
     @property
     def analyte_name(self) -> str:

--- a/python/src/pypalmsens/_data/peak.py
+++ b/python/src/pypalmsens/_data/peak.py
@@ -21,8 +21,8 @@ class Peak:
     Obtain internal instances via `_wrap`.
     """
 
-    __slots__: ClassVar[tuple[str, ...]] = ('_pspeak',)
-    _pspeak: PSPeak  # pyright: ignore[reportUninitializedInstanceVariable]
+    __slots__: ClassVar[tuple[str, ...]] = ('_internal',)
+    _internal: PSPeak  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def __init__(self):
         raise TypeError(
@@ -32,7 +32,7 @@ class Peak:
     @classmethod
     def _wrap(cls, pspeak: PSPeak) -> Self:
         obj = cls.__new__(cls)
-        obj._pspeak = pspeak
+        obj._internal = pspeak
         return obj
 
     @override
@@ -54,110 +54,110 @@ class Peak:
         """Parent curve associated with Peak."""
         from .curve import Curve
 
-        return Curve._wrap(self._pspeak.Curve)
+        return Curve._wrap(self._internal.Curve)
 
     @property
     def analyte_name(self) -> str:
         """Name of analyte."""
-        return self._pspeak.AnalyteName
+        return self._internal.AnalyteName
 
     @analyte_name.setter
     def analyte_name(self, name: str):
         """Set name of analyte."""
-        self._pspeak.set_AnalyteName(name)
+        self._internal.set_AnalyteName(name)
 
     @property
     def area(self) -> float:
         """Area of the peak."""
-        return single_to_double(self._pspeak.Area)
+        return single_to_double(self._internal.Area)
 
     @property
     def label(self) -> str:
         """Formatted label for the peak value."""
-        return self._pspeak.Label
+        return self._internal.Label
 
     @property
     def left_index(self) -> int:
         """Left side of the peaks baseline as index number of the curve."""
-        return self._pspeak.LeftIndex
+        return self._internal.LeftIndex
 
     @property
     def left_x(self) -> float:
         """X of the left side of the peak baseline."""
-        return single_to_double(self._pspeak.LeftX)
+        return single_to_double(self._internal.LeftX)
 
     @property
     def left_y(self) -> float:
         """Y of the left side of the peak baseline."""
-        return single_to_double(self._pspeak.LeftY)
+        return single_to_double(self._internal.LeftY)
 
     @property
     def maximum_of_derivative_neg(self) -> float:
         """Maximum derivative of the negative slope of the peak."""
-        return single_to_double(self._pspeak.MaximumOfDerivativeNeg)
+        return single_to_double(self._internal.MaximumOfDerivativeNeg)
 
     @property
     def maximum_of_derivative_pos(self) -> float:
         """Maximum derivative of the positive slope of the peak."""
-        return single_to_double(self._pspeak.MaximumOfDerivativePos)
+        return single_to_double(self._internal.MaximumOfDerivativePos)
 
     @property
     def maximum_of_derivative_sum(self) -> float:
         """Sum of the absolute values for both the positive and negative maximum derivative."""
-        return single_to_double(self._pspeak.MaximumOfDerivativeSum)
+        return single_to_double(self._internal.MaximumOfDerivativeSum)
 
     @property
     def notes(self) -> str:
         """User notes stored on this peak."""
-        return self._pspeak.Notes
+        return self._internal.Notes
 
     @property
     def y_offset(self) -> float:
         """Offset of Y."""
-        return single_to_double(self._pspeak.OffsetY)
+        return single_to_double(self._internal.OffsetY)
 
     @property
     def index(self) -> int:
         """Location of the peak as index number of the curve."""
-        return self._pspeak.PeakIndex
+        return self._internal.PeakIndex
 
     @property
     def type(self) -> str:
         """Used to determine if a peak is auto found."""
-        return str(self._pspeak.PeakType)
+        return str(self._internal.PeakType)
 
     @property
     def value(self) -> float:
         """Value of the peak in units of the curve.
         This is the value of the peak height relative to the baseline of the peak."""
-        return single_to_double(self._pspeak.PeakValue)
+        return single_to_double(self._internal.PeakValue)
 
     @property
     def x(self) -> float:
         """X value of the peak."""
-        return single_to_double(self._pspeak.PeakX)
+        return single_to_double(self._internal.PeakX)
 
     @property
     def y(self) -> float:
         """Y value of the peak."""
-        return single_to_double(self._pspeak.PeakY)
+        return single_to_double(self._internal.PeakY)
 
     @property
     def right_index(self) -> int:
         """Left side of the peaks baseline as index number of the curve."""
-        return self._pspeak.RightIndex
+        return self._internal.RightIndex
 
     @property
     def right_x(self) -> float:
         """X of the right side of the peak baseline."""
-        return single_to_double(self._pspeak.RightX)
+        return single_to_double(self._internal.RightX)
 
     @property
     def right_y(self) -> float:
         """Returns the Y of the right side of the peak baseline."""
-        return single_to_double(self._pspeak.RightY)
+        return single_to_double(self._internal.RightY)
 
     @property
     def width(self) -> float:
         """Full width at half-height of the peak."""
-        return single_to_double(self._pspeak.Width)
+        return single_to_double(self._internal.Width)

--- a/python/src/pypalmsens/_data/peak.py
+++ b/python/src/pypalmsens/_data/peak.py
@@ -22,10 +22,9 @@ class Peak:
     """
 
     __slots__: ClassVar[tuple[str, ...]] = ('_pspeak',)
+    _pspeak: PSPeak  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def __init__(self):
-        self._pspeak: PSPeak
-
         raise TypeError(
             'Peak cannot be instantiated directly. Obtain instances through the Curve methods.'
         )

--- a/python/src/pypalmsens/_fitting.py
+++ b/python/src/pypalmsens/_fitting.py
@@ -181,7 +181,7 @@ class FitResult:
     def get_psmodel(self, data: EISData) -> PSModels.CircuitModel:
         """Get SDK Circuit model object."""
         psmodel = PSModels.CircuitModel()
-        psmodel.SetEISdata(data._pseis)
+        psmodel.SetEISdata(data._internal)
         psmodel.SetCircuit(self.cdc)
         psmodel.SetInitialParameters(self.parameters)
         return psmodel
@@ -408,7 +408,7 @@ class CircuitModel:
         """
         model = PSModels.CircuitModel()
         model.SetCircuit(self.cdc)
-        model.SetEISdata(data._pseis)
+        model.SetEISdata(data._internal)
 
         if parameters:
             if isinstance(parameters, Parameters):
@@ -424,7 +424,7 @@ class CircuitModel:
 
         opts = PSFitting.FitOptionsCircuit()
         opts.Model = model
-        opts.RawData = data._pseis
+        opts.RawData = data._internal
 
         opts.MaxIterations = self.max_iterations
         opts.MinimumDeltaErrorTerm = self.min_delta_error

--- a/python/src/pypalmsens/_instruments/filesystem.py
+++ b/python/src/pypalmsens/_instruments/filesystem.py
@@ -208,7 +208,7 @@ class DeviceFileSystem:
 
         psmeasurement = self._client_connection.LoadDeviceFile(f)
 
-        return Measurement(psmeasurement=psmeasurement)
+        return Measurement._wrap(psmeasurement)
 
     def remove(self, path: str | DevicePath) -> None:
         """Remove a file from the device.

--- a/python/src/pypalmsens/_instruments/filesystem_async.py
+++ b/python/src/pypalmsens/_instruments/filesystem_async.py
@@ -167,7 +167,7 @@ class DeviceFileSystemAsync:
                 self._client_connection.LoadDeviceFileAsync(f)
             )
 
-        return Measurement(psmeasurement=psmeasurement)
+        return Measurement._wrap(psmeasurement)
 
     async def remove(self, path: str | DevicePath) -> None:
         """Remove a file from the device.

--- a/python/src/pypalmsens/_instruments/measurement_manager_async.py
+++ b/python/src/pypalmsens/_instruments/measurement_manager_async.py
@@ -406,7 +406,7 @@ class MeasurementManagerAsync:
 
         self.eis_last_data_index = 0
 
-        data = EISData(pseis=eis_data)
+        data = EISData._wrap(eis_data)
 
         for callback in self.callbacks['eis_data_begin']:
             _ = self.loop.call_soon_threadsafe(callback, data)

--- a/python/src/pypalmsens/_instruments/measurement_manager_async.py
+++ b/python/src/pypalmsens/_instruments/measurement_manager_async.py
@@ -284,7 +284,7 @@ class MeasurementManagerAsync:
         self, sender: PalmSens.Comm.CommManager, args
     ) -> Task.CompletedTask:
         """Called when the measurement begins."""
-        measurement = Measurement(psmeasurement=args.NewMeasurement)
+        measurement = Measurement._wrap(args.NewMeasurement)
 
         self.last_measurement = measurement
 
@@ -372,7 +372,7 @@ class MeasurementManagerAsync:
             return
 
         data = CallbackDataEIS(
-            data=DataSet(psdataset=eis_data.EISDataSet),
+            data=DataSet._wrap(eis_data.EISDataSet),
             start=self.eis_last_data_index,
             index=count - 1,
             id=eis_data.GetHashCode(),

--- a/python/src/pypalmsens/_instruments/measurement_manager_async.py
+++ b/python/src/pypalmsens/_instruments/measurement_manager_async.py
@@ -276,7 +276,7 @@ class MeasurementManagerAsync:
         assert self.last_measurement
 
         if isinstance(method, BaseMethodScriptTechnique):
-            self.last_measurement._psmeasurement.Title = method._name  # type: ignore
+            self.last_measurement._internal.Title = method._name  # type: ignore
 
         return self.last_measurement
 

--- a/python/src/pypalmsens/_io.py
+++ b/python/src/pypalmsens/_io.py
@@ -71,7 +71,7 @@ def load_session_file(
     for psmeasurement in session:
         psmeasurement.Method.MethodFilename = str(path.absolute())
 
-    return [Measurement(psmeasurement=m) for m in session]
+    return [Measurement._wrap(m) for m in session]
 
 
 def save_session_file(path: str | Path, measurements: Sequence[Measurement]):
@@ -160,7 +160,7 @@ def _load_method_file(path: str | Path) -> Method:
 
     psmethod.MethodFilename = str(path.absolute())
 
-    return Method(psmethod=psmethod)
+    return Method._wrap(psmethod)
 
 
 def load_method_file(path: str | Path) -> MethodType:

--- a/python/src/pypalmsens/_io.py
+++ b/python/src/pypalmsens/_io.py
@@ -90,11 +90,11 @@ def save_session_file(path: str | Path, measurements: Sequence[Measurement]):
         raise ValueError('`measurements` must be a non-empty sequence of Measurement objects')
 
     session = PalmSens.Data.SessionManager()
-    session.MethodForEditor = measurements[0]._psmeasurement.Method
+    session.MethodForEditor = measurements[0]._internal.Method
     session.MethodForEditor.MethodFilename = str(path.absolute())
 
     for measurement in measurements:
-        session.AddMeasurement(measurement._psmeasurement)
+        session.AddMeasurement(measurement._internal)
 
     with stream_writer(str(path), append=False, encoding=Encoding.Unicode) as stream:
         session.Save(stream.BaseStream, str(path))

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -212,14 +212,14 @@ def test_constructor():
     assert arr.name == 'test'
     assert arr.type == 'Time'
     assert arr.unit == 's'
-    assert isinstance(arr._psarray, PSData.DataArray)
+    assert isinstance(arr._internal, PSData.DataArray)
 
     c_arr = CurrentArray([1, 2, 3])
-    assert isinstance(c_arr._psarray, PSData.DataArrayCurrents)
+    assert isinstance(c_arr._internal, PSData.DataArrayCurrents)
     assert c_arr.unit == 'µA'
 
     p_arr = PotentialArray([1, 2, 3])
-    assert isinstance(p_arr._psarray, PSData.DataArrayPotentials)
+    assert isinstance(p_arr._internal, PSData.DataArrayPotentials)
     assert p_arr.unit == 'V'
 
     g_arr = DataArray([1, 2, 3])

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -60,7 +60,7 @@ def test_array_copy(array):
     new_array = array.copy()
     assert list(array) == list(new_array)  # data must match
     assert array is not new_array
-    assert array._psarray is not new_array._psarray
+    assert array._internal is not new_array._internal
 
 
 def test_array_status(measurement_cv_1scan):

--- a/python/tests/test_curve.py
+++ b/python/tests/test_curve.py
@@ -110,9 +110,9 @@ def test_curve_properties(curve_dpv):
 def test_curve_copy(curve_dpv):
     new_curve = curve_dpv.copy()
     assert curve_dpv is not new_curve
-    assert curve_dpv._pscurve is not new_curve._pscurve
-    assert curve_dpv._pscurve.XAxisDataArray is not new_curve._pscurve.XAxisDataArray
-    assert curve_dpv._pscurve.YAxisDataArray is not new_curve._pscurve.YAxisDataArray
+    assert curve_dpv._internal is not new_curve._internal
+    assert curve_dpv._internal.XAxisDataArray is not new_curve._internal.XAxisDataArray
+    assert curve_dpv._internal.YAxisDataArray is not new_curve._internal.YAxisDataArray
 
 
 def test_curve_add(curve_dpv):

--- a/python/tests/test_curve.py
+++ b/python/tests/test_curve.py
@@ -57,7 +57,6 @@ def test_find_peaks(curve_dpv):
         12.203112,
         33.240610,
     ]
-    assert peaks[0].curve_title == curve_dpv.title
 
     curve_dpv.clear_peaks()
     assert not curve_dpv.peaks
@@ -73,7 +72,6 @@ def test_find_peaks_semiderivative(curve_cv):
 
     assert [peak.x for peak in peaks] == [0.284884, -0.0223047]
     assert [peak.y for peak in peaks] == [15.8404, -15.826]
-    assert peaks[0].curve_title == curve.title
 
     curve.clear_peaks()
     assert not curve.peaks

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import pytest
 
-from pypalmsens.data import DataArray
+from pypalmsens.data import DataArray, DataSet
 
 
 @pytest.fixture
 def dataset(measurement_cv_1scan):
     return measurement_cv_1scan.dataset
+
+
+def test_dataset_init_fail():
+    with pytest.raises(TypeError):
+        _ = DataSet()
 
 
 def test_mapping(dataset):

--- a/python/tests/test_eis_data.py
+++ b/python/tests/test_eis_data.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+from pypalmsens.data import EISData
+
 
 @pytest.fixture
 def eis_simple(measurement_eis_5freq):
@@ -11,6 +13,11 @@ def eis_simple(measurement_eis_5freq):
 @pytest.fixture
 def eis_mux_subscans(measurement_eis_3ch_4scan_5freq):
     return measurement_eis_3ch_4scan_5freq.eis_data
+
+
+def test_eisdata_init_fail():
+    with pytest.raises(TypeError):
+        _ = EISData()
 
 
 def test_eis_data(eis_simple):

--- a/python/tests/test_io.py
+++ b/python/tests/test_io.py
@@ -21,7 +21,7 @@ def test_save_load_session(tmpdir, measurement_dpv):
 
     measurement_dpv2 = session2[0]
 
-    method_filename = Path(measurement_dpv2._psmeasurement.Method.MethodFilename)
+    method_filename = Path(measurement_dpv2._internal.Method.MethodFilename)
     assert method_filename == path
     assert method_filename.is_absolute()
 

--- a/python/tests/test_measurement.py
+++ b/python/tests/test_measurement.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 import pytest
 
-from pypalmsens.data import Curve
+from pypalmsens.data import Curve, Measurement
 
 
 @pytest.fixture
@@ -30,3 +30,8 @@ def test_measurement_properties(measurement):
     device = measurement.device
     with pytest.raises(FrozenInstanceError):
         device.type = 'foo'
+
+
+def test_measurement_init_fail():
+    with pytest.raises(TypeError):
+        _ = Measurement()

--- a/python/tests/test_measurement.py
+++ b/python/tests/test_measurement.py
@@ -13,6 +13,11 @@ def measurement(measurement_dpv):
     return measurement_dpv
 
 
+def test_measurement_init_fail():
+    with pytest.raises(TypeError):
+        _ = Measurement()
+
+
 def test_measurement_properties(measurement):
     assert measurement.title == 'Square Wave Voltammetry'
     assert isinstance(measurement.timestamp, datetime)
@@ -30,8 +35,3 @@ def test_measurement_properties(measurement):
     device = measurement.device
     with pytest.raises(FrozenInstanceError):
         device.type = 'foo'
-
-
-def test_measurement_init_fail():
-    with pytest.raises(TypeError):
-        _ = Measurement()

--- a/python/tests/test_method.py
+++ b/python/tests/test_method.py
@@ -9,7 +9,7 @@ from pypalmsens._methods.adapters import technique_adapter
 
 @pytest.fixture
 def method(measurement_cv_1scan):
-    return Method._wrap(measurement_cv_1scan._psmeasurement.Method)
+    return Method._wrap(measurement_cv_1scan._internal.Method)
 
 
 def test_method_init_fail():

--- a/python/tests/test_method.py
+++ b/python/tests/test_method.py
@@ -9,7 +9,7 @@ from pypalmsens._methods.adapters import technique_adapter
 
 @pytest.fixture
 def method(measurement_cv_1scan):
-    return Method(psmethod=measurement_cv_1scan._psmeasurement.Method)
+    return Method._wrap(measurement_cv_1scan._psmeasurement.Method)
 
 
 def test_properties(method):

--- a/python/tests/test_method.py
+++ b/python/tests/test_method.py
@@ -12,6 +12,11 @@ def method(measurement_cv_1scan):
     return Method._wrap(measurement_cv_1scan._psmeasurement.Method)
 
 
+def test_method_init_fail():
+    with pytest.raises(TypeError):
+        _ = Method()
+
+
 def test_properties(method):
     assert isinstance(repr(method), str)
     assert method.id == 'cv'

--- a/python/tests/test_peak.py
+++ b/python/tests/test_peak.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+from pypalmsens.data import Peak
+
 
 @pytest.fixture
 def peak(measurement_dpv):
@@ -11,6 +13,11 @@ def peak(measurement_dpv):
         min_peak_height=0,
     )
     return peaks[0]
+
+
+def test_peak_init_fail():
+    with pytest.raises(TypeError):
+        _ = Peak()
 
 
 def test_peak_properties(peak):

--- a/python/tests/test_peak.py
+++ b/python/tests/test_peak.py
@@ -14,9 +14,6 @@ def peak(measurement_dpv):
 
 
 def test_peak_properties(peak):
-    assert peak.curve_title == 'dpvexample'
-    assert peak.x_unit == 'V'
-    assert peak.y_unit == 'µA'
     assert peak.analyte_name is None
     assert peak.area == pytest.approx(0.08553185)
     assert peak.label == '1.465'

--- a/python/tests/test_techniques.py
+++ b/python/tests/test_techniques.py
@@ -228,7 +228,7 @@ class CV:
         for curve in measurement.curves:
             assert curve.n_points >= 5
 
-        assert measurement._psmeasurement.Method.nScans == 2
+        assert measurement._internal.Method.nScans == 2
 
         dataset = measurement.dataset
         assert len(dataset) == 7
@@ -267,9 +267,9 @@ class FCV:
         for curve in measurement.curves:
             assert curve.n_points >= 5
 
-        assert measurement._psmeasurement.Method.nScans == 3
-        assert measurement._psmeasurement.Method.nAvgScans == 2
-        assert measurement._psmeasurement.Method.nEqScans == 2
+        assert measurement._internal.Method.nScans == 3
+        assert measurement._internal.Method.nAvgScans == 2
+        assert measurement._internal.Method.nEqScans == 2
 
         dataset = measurement.dataset
 
@@ -405,7 +405,7 @@ class SWV:
         for curve in measurement.curves:
             assert curve.n_points >= 5
 
-        assert measurement._psmeasurement.Method.nScans == 1
+        assert measurement._internal.Method.nScans == 1
 
         dataset = measurement.dataset
         assert len(dataset) == 5


### PR DESCRIPTION
This PR updates the wrappers for:

- pypalmsens.data.EISData
- pypalmsens.data.DataSet
- pypalmsens.data.Measurement
- pypalmsens.data.Peak
- pypalmsens.data.Method

These now raise `TypeError` when initiated directly, reserving `__init__` for a future public API.